### PR TITLE
chore: derive __version__ from package metadata

### DIFF
--- a/src/stonks_cli/__init__.py
+++ b/src/stonks_cli/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("stonks-cli")


### PR DESCRIPTION
Instead of hardcoding the version string, read it dynamically from the installed package metadata via importlib.metadata. This ensures the version reported at runtime always matches pyproject.toml without requiring a manual update in two places on every release.