### PR TITLE
feat: add --version / -V flag

### DIFF
--- a/src/stonks_cli/main.py
+++ b/src/stonks_cli/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 
+from stonks_cli import __version__
 from stonks_cli.app import PortfolioApp
 from stonks_cli.storage import PORTFOLIO_CONFIG_DIR, PortfolioStore
 
@@ -24,6 +25,7 @@ def _resolve_portfolio_path(name_or_path: str | None) -> Path | None:
 
 
 @click.group()
+@click.version_option(__version__, "--version", "-V")
 @click.option(
     "-p",
     "--portfolio",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from stonks_cli import __version__
 from stonks_cli.main import _resolve_portfolio_path, main
 from stonks_cli.storage import PORTFOLIO_CONFIG_DIR, PortfolioStore
 
@@ -300,6 +301,14 @@ class TestList:
             result = runner.invoke(main, ["list"])
         assert "notes" not in result.output
         assert "work" in result.output
+
+
+class TestVersion:
+    @pytest.mark.parametrize("flag", ["--version", "-V"])
+    def test_prints_version(self, runner, flag):
+        result = runner.invoke(main, [flag])
+        assert result.exit_code == 0
+        assert __version__ in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Expose the package version via Click's built-in version_option, reading it from the already-declared __version__ in __init__.py.