### PR TITLE
chore: add make_release.sh release automation script

### DIFF
--- a/make_release.sh
+++ b/make_release.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# make_release.sh -- tag, build, publish, and create a GitHub release.
+#
+# Usage:
+#   ./make_release.sh
+#
+# Prerequisites:
+#   - Poetry installed and configured (pypi-token.testpypi / pypi-token.pypi)
+#   - TestPyPI repository registered: poetry config repositories.testpypi https://test.pypi.org/legacy/
+#   - gh CLI authenticated
+#   - Working tree must be clean
+#   - Current branch must be main
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()  { echo "==> $*"; }
+ok()    { echo "OK: $*"; }
+die()   { echo "ERROR: $*" >&2; exit 1; }
+skip()  { echo "SKIP: $*"; }
+
+confirm() {
+    # confirm <question>  -- exits 0 if user answers y/Y, 1 otherwise
+    local prompt="$1"
+    local _ans
+    read -rp "${prompt} [y/N] " _ans
+    [[ "${_ans}" == "y" || "${_ans}" == "Y" ]]
+}
+
+# ---------------------------------------------------------------------------
+# 1. Read version from pyproject.toml
+# ---------------------------------------------------------------------------
+VERSION=$(poetry version --short)
+[[ -z "$VERSION" ]] && die "Could not read version from pyproject.toml"
+TAG="v${VERSION}"
+
+info "Release: ${VERSION}  Tag: ${TAG}"
+
+# ---------------------------------------------------------------------------
+# 2. Sanity checks (non-interactive)
+# ---------------------------------------------------------------------------
+info "Running sanity checks"
+
+[[ -z "$(git status --porcelain)" ]] || die "Working tree is dirty; commit or stash changes first"
+ok "Working tree is clean"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" == "main" ]] || die "Must be on main branch (currently on '${BRANCH}')"
+ok "On main branch"
+
+git rev-parse --verify "${TAG}" &>/dev/null && die "Tag ${TAG} already exists"
+ok "Tag ${TAG} does not exist yet"
+
+# ---------------------------------------------------------------------------
+# 3. Create annotated tag
+# ---------------------------------------------------------------------------
+info "Step 1/6 -- Create annotated tag ${TAG}"
+git log --oneline -5
+confirm "Create annotated tag ${TAG}?" || { skip "Tag skipped -- aborting"; exit 0; }
+git tag -a "${TAG}" -m "stonks-cli v${VERSION}"
+ok "Tag ${TAG} created"
+
+# ---------------------------------------------------------------------------
+# 4. Push commits + tag to remote
+# ---------------------------------------------------------------------------
+info "Step 2/6 -- Push main branch and tag to origin"
+git log --oneline origin/main..HEAD 2>/dev/null || true
+confirm "Push main and ${TAG} to origin?" || { skip "Push skipped -- aborting"; exit 0; }
+git push origin main
+git push origin "${TAG}"
+ok "Pushed main and ${TAG}"
+
+# ---------------------------------------------------------------------------
+# 5. Clean dist/ and build
+# ---------------------------------------------------------------------------
+info "Step 3/6 -- Build distribution"
+[[ -d dist/ ]] && echo "Current dist/ contents:" && ls dist/ || true
+confirm "Clean dist/ and run 'poetry build'?" || { skip "Build skipped -- aborting"; exit 0; }
+rm -rf dist/
+poetry build
+ok "Build complete"
+ls -lh dist/
+
+# ---------------------------------------------------------------------------
+# 6. Publish to TestPyPI
+# ---------------------------------------------------------------------------
+info "Step 4/6 -- Publish to TestPyPI"
+echo "Artifacts to upload:"
+ls dist/
+confirm "Publish to TestPyPI?" || { skip "TestPyPI publish skipped -- aborting"; exit 0; }
+poetry publish --repository testpypi
+ok "Published to TestPyPI"
+echo "Verify at: https://test.pypi.org/project/stonks-cli/${VERSION}/"
+
+# ---------------------------------------------------------------------------
+# 7. Publish to PyPI
+# ---------------------------------------------------------------------------
+info "Step 5/6 -- Publish to production PyPI"
+confirm "TestPyPI looks good? Publish to production PyPI?" || { skip "PyPI publish skipped -- aborting"; exit 0; }
+poetry publish
+ok "Published to PyPI"
+echo "Verify at: https://pypi.org/project/stonks-cli/${VERSION}/"
+
+# ---------------------------------------------------------------------------
+# 8. Create GitHub release
+# ---------------------------------------------------------------------------
+info "Step 6/6 -- Create GitHub release"
+NOTES=$(awk -v v="[${VERSION}]" '
+    $2 == v { found=1; next }
+    /^## \[/ && found { exit }
+    found { print }
+' CHANGELOG.md | sed '1{/^$/d}')
+
+echo "Release notes preview:"
+echo "---"
+echo "${NOTES}"
+echo "---"
+confirm "Create GitHub release ${TAG}?" || { skip "GitHub release skipped"; exit 0; }
+gh release create "${TAG}" dist/* \
+    --title "stonks-cli v${VERSION}" \
+    --notes "${NOTES}"
+ok "GitHub release created: $(gh release view "${TAG}" --json url -q .url)"


### PR DESCRIPTION
Automates the full release workflow described in RELEASING.md: reads the version from pyproject.toml, runs sanity checks (clean working tree, on main, tag does not exist), then walks through each step with an explicit confirmation prompt before proceeding:

  1. Create annotated tag vX.Y.Z
  2. Push main and tag to origin
  3. Clean dist/ and run poetry build
  4. Publish to TestPyPI
  5. Publish to production PyPI
  6. Create GitHub release with notes extracted from CHANGELOG.md

Answering N at any prompt aborts cleanly without side effects on subsequent steps.