### PR TITLE
feat(log): use per-process log file to allow safe concurrent instances

### DIFF
--- a/src/stonks_cli/log.py
+++ b/src/stonks_cli/log.py
@@ -1,18 +1,49 @@
 """Logging configuration for stonks-cli."""
 
 import logging
-import logging.handlers
+import os
+import re
+import time
 from pathlib import Path
 
 from platformdirs import user_log_dir
 from rich.console import Console
 from rich.logging import RichHandler
 
-# ~/.local/state/stonks/log/stonks.log  (Linux / macOS XDG)
-# ~/Library/Logs/stonks/stonks.log      (macOS native)
-# %LOCALAPPDATA%\stonks\Logs\stonks.log (Windows)
+# ~/.local/state/stonks/log/  (Linux / macOS XDG)
+# ~/Library/Logs/stonks/      (macOS native)
+# %LOCALAPPDATA%\stonks\Logs\ (Windows)
 LOG_DIR = Path(user_log_dir("stonks"))
-LOG_FILE = LOG_DIR / "stonks.log"
+# Per-process file: stonks.<pid>.log -- safe for concurrent instances.
+LOG_FILE = LOG_DIR / f"stonks.{os.getpid()}.log"
+
+
+_LOG_MAX_AGE_DAYS = 30
+_LOG_FILE_RE = re.compile(r"stonks\.(\d+)\.log")
+
+
+def _cleanup_stale_log_files() -> None:
+    """Remove log files older than ``_LOG_MAX_AGE_DAYS`` days.
+
+    Called once at startup so per-process files do not accumulate
+    indefinitely.  Failures to remove a specific file are logged as
+    warnings so permission issues stay visible.
+    """
+    cutoff = time.time() - _LOG_MAX_AGE_DAYS * 24 * 60 * 60
+    own_pid = os.getpid()
+    for path in LOG_DIR.glob("stonks.*.log"):
+        m = _LOG_FILE_RE.fullmatch(path.name)
+        if not m:
+            continue
+        if int(m.group(1)) == own_pid:
+            continue
+        try:
+            if path.stat().st_mtime < cutoff:
+                path.unlink(missing_ok=True)
+        except OSError:
+            logging.getLogger("stonks_cli").warning(
+                "Failed to remove stale log file %s", path
+            )
 
 
 def setup_logging(level: int = logging.WARNING) -> None:
@@ -20,8 +51,8 @@ def setup_logging(level: int = logging.WARNING) -> None:
 
     Two handlers are attached to the ``stonks_cli`` root logger:
 
-    * **RotatingFileHandler** -- *level* and above, written to :data:`LOG_FILE`
-      (max 1 MB, 3 backups).
+    * **FileHandler** -- *level* and above, written to :data:`LOG_FILE`
+      (``stonks.<pid>.log``; one file per process, no rotation contention).
     * **RichHandler** -- *level* and above, written to *stderr*.
       Surfaces warnings/errors in the terminal without interfering with
       normal CLI output or the Textual TUI screen.
@@ -52,9 +83,8 @@ def setup_logging(level: int = logging.WARNING) -> None:
     # --- file handler (best-effort) ---
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True)
-        fh = logging.handlers.RotatingFileHandler(
-            LOG_FILE, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
-        )
+        _cleanup_stale_log_files()
+        fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
         fh.setLevel(level)
         fh.setFormatter(
             logging.Formatter(

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,13 +1,15 @@
 """Tests for stonks_cli.log (setup_logging)."""
 
 import logging
-import logging.handlers
+import os
+import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from rich.logging import RichHandler
 
-from stonks_cli.log import setup_logging
+from stonks_cli.log import _LOG_MAX_AGE_DAYS, _cleanup_stale_log_files, setup_logging
 
 
 @pytest.fixture(autouse=True)
@@ -38,9 +40,7 @@ class TestSetupLogging:
 
         logger = logging.getLogger("stonks_cli")
         file_handlers = [
-            h
-            for h in logger.handlers
-            if isinstance(h, logging.handlers.RotatingFileHandler)
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
         ]
         assert len(file_handlers) == 1
 
@@ -118,7 +118,7 @@ class TestSetupLogging:
             patch("stonks_cli.log.LOG_DIR", log_dir),
             patch("stonks_cli.log.LOG_FILE", log_dir / "stonks.log"),
             patch(
-                "stonks_cli.log.logging.handlers.RotatingFileHandler",
+                "stonks_cli.log.logging.FileHandler",
                 side_effect=OSError("no space left"),
             ),
         ):
@@ -128,3 +128,62 @@ class TestSetupLogging:
         # Only the RichHandler should be attached; no file handler.
         assert len(logger.handlers) == 1
         assert isinstance(logger.handlers[0], RichHandler)
+
+
+class TestCleanupStaleLogFiles:
+    def _make_old(self, path, days=_LOG_MAX_AGE_DAYS + 1):
+        """Write a file and backdate its mtime by *days* days."""
+        path.write_text("old log")
+        old_mtime = time.time() - days * 24 * 60 * 60
+        os.utime(path, (old_mtime, old_mtime))
+
+    def test_removes_old_file(self, tmp_path):
+        stale = tmp_path / "stonks.999999999.log"
+        self._make_old(stale)
+        with patch("stonks_cli.log.LOG_DIR", tmp_path):
+            _cleanup_stale_log_files()
+        assert not stale.exists()
+
+    def test_keeps_recent_file(self, tmp_path):
+        recent = tmp_path / "stonks.999999999.log"
+        recent.write_text("recent log")  # mtime = now
+        with patch("stonks_cli.log.LOG_DIR", tmp_path):
+            _cleanup_stale_log_files()
+        assert recent.exists()
+
+    def test_keeps_own_pid_file(self, tmp_path):
+        own = tmp_path / f"stonks.{os.getpid()}.log"
+        self._make_old(own)
+        with patch("stonks_cli.log.LOG_DIR", tmp_path):
+            _cleanup_stale_log_files()
+        assert own.exists()
+
+    def test_ignores_unrelated_files(self, tmp_path):
+        other = tmp_path / "other.log"
+        self._make_old(other)
+        with patch("stonks_cli.log.LOG_DIR", tmp_path):
+            _cleanup_stale_log_files()
+        assert other.exists()
+
+    def test_warns_on_oserror(self, tmp_path, caplog):
+        stale = tmp_path / "stonks.999999999.log"
+        self._make_old(stale)
+        _real_unlink = Path.unlink
+
+        def _failing_unlink(self, *args, **kwargs):
+            if self.name == stale.name:
+                raise OSError("permission denied")
+            return _real_unlink(self, *args, **kwargs)
+
+        with (
+            patch("stonks_cli.log.LOG_DIR", tmp_path),
+            patch("pathlib.Path.unlink", _failing_unlink),
+            caplog.at_level(logging.WARNING, logger="stonks_cli"),
+        ):
+            _cleanup_stale_log_files()
+        assert any("stale log file" in r.message for r in caplog.records)
+
+    def test_noop_when_log_dir_missing(self, tmp_path):
+        missing = tmp_path / "nonexistent"
+        with patch("stonks_cli.log.LOG_DIR", missing):
+            _cleanup_stale_log_files()  # must not raise


### PR DESCRIPTION
Switch from RotatingFileHandler to a plain FileHandler writing to stonks.<pid>.log. Each process gets its own file so concurrent stonks instances never interleave writes or contend on rotation.