### PR TITLE
fix(app): ignore shutdown-time refresh race

### DIFF
--- a/src/stonks_cli/app.py
+++ b/src/stonks_cli/app.py
@@ -364,6 +364,25 @@ class PortfolioApp(App[None]):
         else:
             widget.remove_class("visible")
 
+    def _call_from_thread_if_running(self, fn, *args) -> bool:
+        """Call *fn* via Textual when the app loop is still alive.
+
+        Worker threads may finish during shutdown, at which point
+        ``call_from_thread`` raises ``RuntimeError("App is not running")``.
+        Treat that race as a harmless no-op.
+        """
+        try:
+            self.call_from_thread(fn, *args)
+        except RuntimeError as exc:
+            if exc.args != ("App is not running",):
+                raise
+            logger.debug(
+                "Skipping UI callback %s because the app is shutting down",
+                getattr(fn, "__name__", repr(fn)),
+            )
+            return False
+        return True
+
     def action_add(self) -> None:
         active = self._get_active_table_and_index()
         if active is None:
@@ -669,13 +688,15 @@ class PortfolioApp(App[None]):
             self._do_refresh_prices()
         except Exception as exc:  # noqa: BLE001
             logger.error("Price refresh failed: %s", exc, exc_info=True)
-            self.call_from_thread(self._show_error, f"Price refresh failed: {exc}")
+            self._call_from_thread_if_running(
+                self._show_error, f"Price refresh failed: {exc}"
+            )
         finally:
             self._refresh_lock.release()
 
     def _do_refresh_prices(self) -> None:
         snap = build_market_snapshot(self.portfolios)
-        self.call_from_thread(self._apply_snapshot, snap)
+        self._call_from_thread_if_running(self._apply_snapshot, snap)
 
     def _apply_snapshot(self, snap: MarketSnapshot) -> None:
         self._snap = snap

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -541,6 +541,34 @@ async def test_refresh_prices_clears_error_bar_on_success(
 
 
 @pytest.mark.asyncio
+async def test_refresh_prices_ignores_shutdown_race(portfolio: Portfolio) -> None:
+    """Shutdown-time call_from_thread failures are treated as a harmless race."""
+    snap = MarketSnapshot(
+        prices={"AAPL": 160.0},
+        sessions={"AAPL": "regular"},
+        exchange_codes={},
+        forex_rates={"USD": {"USD": 1.0}},
+        prev_closes={},
+    )
+
+    with patch("stonks_cli.app.build_market_snapshot", return_value=snap):
+        app = PortfolioApp(portfolios=[portfolio], prices={}, forex_rates=USD_RATES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            def _raise_not_running(fn, *a, **kw):
+                raise RuntimeError("App is not running")
+
+            app.call_from_thread = _raise_not_running
+
+            # Must not raise even though the UI loop is already considered gone.
+            _REAL_REFRESH_PRICES.__wrapped__(app)
+            await pilot.pause()
+
+    assert app._snap.prices == {}
+
+
+@pytest.mark.asyncio
 async def test_sort_by_column_header(portfolio: Portfolio) -> None:
     """Clicking a column header sorts the table by that column."""
     prices = {"AAPL": 160.0, "NVDA": 90.0}


### PR DESCRIPTION
Treat Textual call_from_thread failures during app shutdown as a benign race in the background price refresh worker.

Add a regression test covering the case where a refresh finishes after the app loop is no longer running.