### PR TITLE
fix(show): keep session badge in last price column

### DIFF
--- a/src/stonks_cli/market_session.py
+++ b/src/stonks_cli/market_session.py
@@ -13,3 +13,11 @@ class Session(str, Enum):
     REGULAR = "regular"
     POST = "post"
     CLOSED = "closed"
+
+
+# Human-readable badge label for each non-regular session.
+SESSION_BADGE: dict[str, str] = {
+    Session.PRE: "PRE",
+    Session.POST: "AH",
+    Session.CLOSED: "CLS",
+}

--- a/src/stonks_cli/show.py
+++ b/src/stonks_cli/show.py
@@ -1,11 +1,10 @@
 """CLI formatted output for portfolio show command."""
 
 from stonks_cli.market import MarketSnapshot
+from stonks_cli.market_session import SESSION_BADGE
 from stonks_cli.models import Portfolio, portfolio_total
 from stonks_cli.table_columns import _TABLE_COLUMNS
 from stonks_cli.table_rows import RowKind, build_row_data
-
-_SESSION_BADGES = {"pre": " PRE", "post": " AH", "closed": " CLS"}
 
 
 def _fmt_chg(pct: float | None) -> str:
@@ -14,6 +13,14 @@ def _fmt_chg(pct: float | None) -> str:
         return "--"
     sign = "+" if pct >= 0 else ""
     return f"{sign}{pct:.2f}%"
+
+
+def _fmt_price(last: float | None, session: str) -> str:
+    """Format the last-price cell with a session badge when applicable."""
+    if last is None:
+        return "N/A"
+    badge = SESSION_BADGE.get(session, "")
+    return f"{last:.2f} {badge}" if badge else f"{last:.2f}"
 
 
 def _collect_rows(portfolio: Portfolio, snap: MarketSnapshot) -> list[tuple[str, ...]]:
@@ -29,14 +36,12 @@ def _collect_rows(portfolio: Portfolio, snap: MarketSnapshot) -> list[tuple[str,
         snap.exchange_codes,
         rates,
     ):
-        badge = _SESSION_BADGES.get(rd.session, "")
         if rd.kind == RowKind.POSITION:
             assert rd.qty is not None and rd.avg_cost is not None
-            instrument = f"{rd.symbol}{badge}"
             if rd.last is None:
                 rows.append(
                     (
-                        instrument,
+                        rd.symbol,
                         rd.exchange,
                         str(rd.qty),
                         f"{rd.avg_cost:.2f}",
@@ -49,25 +54,24 @@ def _collect_rows(portfolio: Portfolio, snap: MarketSnapshot) -> list[tuple[str,
             else:
                 rows.append(
                     (
-                        instrument,
+                        rd.symbol,
                         rd.exchange,
                         str(rd.qty),
                         f"{rd.avg_cost:.2f}",
-                        f"{rd.last:.2f}",
+                        _fmt_price(rd.last, rd.session),
                         _fmt_chg(rd.chg_pct),
                         f"{rd.mkt_value:,.2f}",
                         f"{rd.pnl:+,.2f}",
                     )
                 )
         elif rd.kind == RowKind.WATCHLIST:
-            instrument = f"{rd.symbol}{badge}"
             rows.append(
                 (
-                    instrument,
+                    rd.symbol,
                     rd.exchange,
                     "-",
                     "-",
-                    "N/A" if rd.last is None else f"{rd.last:.2f}",
+                    _fmt_price(rd.last, rd.session),
                     _fmt_chg(rd.chg_pct),
                     "-",
                     "-",

--- a/src/stonks_cli/table_rows.py
+++ b/src/stonks_cli/table_rows.py
@@ -16,7 +16,7 @@ from typing import Any, NamedTuple
 from rich.text import Text
 
 from stonks_cli.exchanges import exchange_label
-from stonks_cli.market_session import Session
+from stonks_cli.market_session import SESSION_BADGE, Session
 from stonks_cli.models import (
     Portfolio,
     daily_change_pct,
@@ -178,14 +178,19 @@ def _format_chg_cell(
     return Text(label, style=style), chg_pct
 
 
+_SESSION_BADGE_STYLE: dict[str, str] = {
+    Session.PRE: "bold yellow",
+    Session.POST: "bold cyan",
+    Session.CLOSED: "bold red",
+}
+
+
 def _format_price_cell(last: float, session: str) -> Text | str:
     """Return a price cell with a session badge appended when applicable."""
-    if session == Session.PRE:
-        return Text(f"{last:.2f} ").append("PRE", style="bold yellow")
-    if session == Session.POST:
-        return Text(f"{last:.2f} ").append("AH", style="bold cyan")
-    if session == Session.CLOSED:
-        return Text(f"{last:.2f} ").append("CLS", style="bold red")
+    badge = SESSION_BADGE.get(session)
+    if badge:
+        style = _SESSION_BADGE_STYLE.get(session, "")
+        return Text(f"{last:.2f} ").append(badge, style=style)
     return f"{last:.2f}"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,6 +514,8 @@ class TestShow:
         result = invoke(runner, portfolio_file, "show")
 
         assert "PRE" in result.output
+        assert "AAPL PRE" not in result.output
+        assert "155.00 PRE" in result.output
 
     @patch("stonks_cli.main.build_market_snapshot")
     def test_session_badge_post(self, mock_fetch, runner, portfolio_file):
@@ -528,6 +530,8 @@ class TestShow:
         result = invoke(runner, portfolio_file, "show")
 
         assert "AH" in result.output
+        assert "AAPL AH" not in result.output
+        assert "155.00 AH" in result.output
 
     @patch("stonks_cli.main.build_market_snapshot")
     def test_session_badge_closed(self, mock_fetch, runner, portfolio_file):
@@ -542,6 +546,8 @@ class TestShow:
         result = invoke(runner, portfolio_file, "show")
 
         assert "CLS" in result.output
+        assert "AAPL CLS" not in result.output
+        assert "155.00 CLS" in result.output
 
     @patch("stonks_cli.main.build_market_snapshot")
     def test_multi_portfolio(self, mock_fetch, runner, tmp_path):


### PR DESCRIPTION
Render PRE/AH/CLS as part of the Last Price cell in the CLI show table instead of appending the badge to the instrument symbol.

Tighten the CLI tests so session badges are asserted in the price column output.

Fixes: 6c35706 ("refactor: split format_show_table into _collect_rows + _render_table")