### PR TITLE
refactor(storage,main): extract load helpers to reduce duplication

### DIFF
--- a/src/stonks_cli/main.py
+++ b/src/stonks_cli/main.py
@@ -18,6 +18,16 @@ from stonks_cli.storage import (
 )
 
 
+def _load_portfolios(stores: list[PortfolioStore]) -> list[Portfolio]:
+    """Load all portfolios from *stores*."""
+    return [store.load() for store in stores]
+
+
+def _is_empty(portfolios: list[Portfolio]) -> bool:
+    """Return True when every portfolio has no positions, cash, or watchlist items."""
+    return not any(p.positions or p.cash or p.watchlist for p in portfolios)
+
+
 def _load_mutate_save(
     store: PortfolioStore, fn: Callable[[Portfolio], None]
 ) -> Portfolio:
@@ -117,9 +127,9 @@ def remove(ctx: click.Context, symbol: str, quantity: int) -> None:
 def dashboard(ctx: click.Context, refresh: float) -> None:
     """Display the current portfolio with live prices and P&L."""
     stores: list[PortfolioStore] = ctx.obj["stores"]
-    portfolios = [store.load() for store in stores]
+    portfolios = _load_portfolios(stores)
 
-    if not any(p.positions or p.cash or p.watchlist for p in portfolios):
+    if _is_empty(portfolios):
         click.echo("Portfolio is empty.")
         return
 
@@ -167,9 +177,9 @@ def remove_cash(ctx: click.Context, currency: str, amount: float) -> None:
 def show(ctx: click.Context) -> None:
     """Print a snapshot of portfolio positions with current prices to stdout."""
     stores: list[PortfolioStore] = ctx.obj["stores"]
-    portfolios = [store.load() for store in stores]
+    portfolios = _load_portfolios(stores)
 
-    if all(not p.positions and not p.cash and not p.watchlist for p in portfolios):
+    if _is_empty(portfolios):
         click.echo("Portfolio is empty.")
         return
 

--- a/src/stonks_cli/storage.py
+++ b/src/stonks_cli/storage.py
@@ -2,13 +2,17 @@
 
 import importlib.resources
 import logging
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import yaml
 
 from stonks_cli.models import CashPosition, Portfolio, Position, WatchlistItem
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +121,27 @@ class PortfolioStore:
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or DEFAULT_PORTFOLIO_PATH
 
+    def _parse_section(
+        self, section: dict, key: str, parser: Callable[[dict], T], label: str
+    ) -> list[T]:
+        """Parse a list section from *section[key]* using *parser*.
+
+        Args:
+            section: The ``portfolio:`` mapping from the YAML file.
+            key: Section key (``"positions"``, ``"cash"``, or ``"watchlist"``).
+            parser: Callable that converts a raw dict to the model instance.
+            label: Singular noun used in error messages (e.g. ``"position"``).
+
+        Raises:
+            ValueError: If any entry is missing a required field.
+        """
+        try:
+            return [parser(item) for item in section.get(key) or []]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                f"Invalid {label} entry in {self.path}: missing required field {exc}"
+            ) from exc
+
     def load(self) -> Portfolio:
         """Load the portfolio from disk.
 
@@ -145,38 +170,16 @@ class PortfolioStore:
                 f"expected a mapping at the top level, got {type(data).__name__}"
             ) from exc
 
-        try:
-            positions = [_parse_position(p) for p in section.get("positions") or []]
-        except (KeyError, TypeError) as exc:
-            raise ValueError(
-                f"Invalid position entry in {self.path}: missing required field {exc}"
-            ) from exc
-
-        try:
-            cash = [_parse_cash(c) for c in section.get("cash") or []]
-        except (KeyError, TypeError) as exc:
-            raise ValueError(
-                f"Invalid cash entry in {self.path}: missing required field {exc}"
-            ) from exc
-
-        try:
-            watchlist = [
-                _parse_watchlist_item(w) for w in section.get("watchlist") or []
-            ]
-        except (KeyError, TypeError) as exc:
-            raise ValueError(
-                f"Invalid watchlist entry in {self.path}: missing required field {exc}"
-            ) from exc
-
-        base_currency = section.get("base_currency", "USD")
-        name = section.get("name") or None
-
         return Portfolio(
-            positions=positions,
-            cash=cash,
-            watchlist=watchlist,
-            base_currency=base_currency,
-            name=name,
+            positions=self._parse_section(
+                section, "positions", _parse_position, "position"
+            ),
+            cash=self._parse_section(section, "cash", _parse_cash, "cash"),
+            watchlist=self._parse_section(
+                section, "watchlist", _parse_watchlist_item, "watchlist"
+            ),
+            base_currency=section.get("base_currency", "USD"),
+            name=section.get("name") or None,
         )
 
     def save(self, portfolio: Portfolio) -> None:


### PR DESCRIPTION
- PortfolioStore._parse_section() consolidates the three identical try/except parse loops in load() into a single reusable helper
- _load_portfolios() and _is_empty() extracted in main.py and shared between dashboard and show commands