### PR TITLE
feat(cli): add stonks detail SYMBOL command

### DIFF
--- a/src/stonks_cli/main.py
+++ b/src/stonks_cli/main.py
@@ -196,6 +196,22 @@ def show(ctx: click.Context) -> None:
             click.echo()
 
 
+@main.command()
+@click.argument("symbol")
+def detail(symbol: str) -> None:
+    """Print detailed financial information for SYMBOL to stdout."""
+    from stonks_cli.show_detail import format_detail
+    from stonks_cli.stock_detail import StockDetailFetcher
+
+    try:
+        d = StockDetailFetcher().fetch_stock_detail(symbol)
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to fetch detail for {symbol.upper()}: {exc}"
+        )
+    click.echo(format_detail(d))
+
+
 @main.command("list")
 def list_portfolios() -> None:
     """List all portfolios in ~/.config/stonks/."""

--- a/src/stonks_cli/show_detail.py
+++ b/src/stonks_cli/show_detail.py
@@ -1,0 +1,99 @@
+"""CLI formatted output for the ``detail`` command."""
+
+from itertools import zip_longest
+
+from stonks_cli.stock_detail import StockDetail
+
+
+def _section(title: str) -> str:
+    return f"\n{title}\n{'-' * len(title)}"
+
+
+def _kv_table(rows: list[tuple[str, str]], indent: int = 2) -> str:
+    if not rows:
+        return ""
+    pad = " " * indent
+    width = max(len(k) for k, _ in rows)
+    return "\n".join(f"{pad}{k:<{width}}  {v}" for k, v in rows)
+
+
+def _performance_section(detail: StockDetail) -> str:
+    if not detail.performance:
+        return ""
+    col_w = max(max(len(k) for k in detail.performance), 6)
+    sym_w = max(len(detail.symbol), 10)
+    lines = [
+        _section("Performance"),
+        f"  {'Metric':<{col_w}}  {detail.symbol:<{sym_w}}  S&P 500",
+        "  " + "-" * (col_w + sym_w + 11),
+    ]
+    for label, (stock_ret, sp_ret) in detail.performance.items():
+        lines.append(f"  {label:<{col_w}}  {stock_ret:<{sym_w}}  {sp_ret}")
+    return "\n".join(lines)
+
+
+def _eps_section(detail: StockDetail) -> str:
+    if not detail.eps_quarters:
+        return ""
+    lines = [
+        _section("EPS (Quarterly)"),
+        f"  {'Quarter':<10}  {'Actual':>8}  {'Estimate':>10}  {'Diff':>8}",
+        "  " + "-" * 42,
+    ]
+    for q, actual, est, diff in zip_longest(
+        detail.eps_quarters,
+        detail.eps_actual,
+        detail.eps_estimate,
+        detail.eps_diff,
+    ):
+        act_s = f"{actual:.2f}" if actual is not None else "N/A"
+        est_s = f"{est:.2f}" if est is not None else "N/A"
+        dif_s = f"{diff:+.2f}" if diff is not None else "N/A"
+        lines.append(f"  {q or 'N/A':<10}  {act_s:>8}  {est_s:>10}  {dif_s:>8}")
+    return "\n".join(lines)
+
+
+def _revenue_section(detail: StockDetail) -> str:
+    if not detail.rev_quarters:
+        return ""
+    lines = [
+        _section("Revenue & Net Income ($B)"),
+        f"  {'Quarter':<10}  {'Revenue':>10}  {'Net Income':>12}",
+        "  " + "-" * 36,
+    ]
+    for q, rev, earn in zip_longest(
+        detail.rev_quarters, detail.rev_values, detail.earn_values
+    ):
+        rev_s = f"{rev:.2f}" if rev is not None else "N/A"
+        earn_s = f"{earn:.2f}" if earn is not None else "N/A"
+        lines.append(f"  {q or 'N/A':<10}  {rev_s:>10}  {earn_s:>12}")
+    return "\n".join(lines)
+
+
+def _analyst_section(detail: StockDetail) -> str:
+    rows: list[tuple[str, str]] = [
+        ("Recommendation", detail.recommendation_key.title() or "N/A"),
+        ("Analysts", str(detail.num_analysts)),
+    ]
+    for k in ("low", "mean", "high"):
+        if k in detail.price_targets:
+            rows.append((f"Target {k.title()}", f"{detail.price_targets[k]:.2f}"))
+    return _section("Analyst Ratings") + "\n" + _kv_table(rows)
+
+
+def format_detail(detail: StockDetail) -> str:
+    """Build a plain-text detail report for a single instrument."""
+    parts = [
+        f"{detail.symbol} -- {detail.name}",
+        _section("Summary"),
+        _kv_table(list(detail.summary.items())),
+        _performance_section(detail),
+        _eps_section(detail),
+        _revenue_section(detail),
+        _analyst_section(detail),
+    ]
+    if detail.valuation:
+        parts += [_section("Valuation"), _kv_table(list(detail.valuation.items()))]
+    if detail.financials:
+        parts += [_section("Financials"), _kv_table(list(detail.financials.items()))]
+    return "\n".join(p for p in parts if p)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -630,6 +630,55 @@ class TestShow:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# detail
+# ---------------------------------------------------------------------------
+
+
+class TestDetail:
+    @patch("stonks_cli.stock_detail.StockDetailFetcher")
+    @patch("stonks_cli.show_detail.format_detail", return_value="AAPL detail output")
+    def test_detail_prints_output(self, mock_fmt, mock_fetcher_cls, runner):
+        result = runner.invoke(main, ["detail", "AAPL"])
+        assert result.exit_code == 0
+        assert "AAPL detail output" in result.output
+
+    @patch("stonks_cli.stock_detail.StockDetailFetcher")
+    @patch("stonks_cli.show_detail.format_detail")
+    def test_detail_calls_fetcher_with_symbol(self, mock_fmt, mock_fetcher_cls, runner):
+        mock_fmt.return_value = "output"
+        runner.invoke(main, ["detail", "MSFT"])
+        mock_fetcher_cls.return_value.fetch_stock_detail.assert_called_once_with("MSFT")
+
+    @patch("stonks_cli.stock_detail.StockDetailFetcher")
+    @patch("stonks_cli.show_detail.format_detail")
+    def test_detail_passes_fetched_data_to_formatter(
+        self, mock_fmt, mock_fetcher_cls, runner
+    ):
+        sentinel = object()
+        mock_fetcher_cls.return_value.fetch_stock_detail.return_value = sentinel
+        mock_fmt.return_value = "out"
+        runner.invoke(main, ["detail", "IBM"])
+        mock_fmt.assert_called_once_with(sentinel)
+
+    @patch("stonks_cli.stock_detail.StockDetailFetcher")
+    @patch("stonks_cli.show_detail.format_detail")
+    def test_detail_fetch_error_shows_click_exception(
+        self, mock_fmt, mock_fetcher_cls, runner
+    ):
+        mock_fetcher_cls.return_value.fetch_stock_detail.side_effect = RuntimeError(
+            "timeout"
+        )
+        result = runner.invoke(main, ["detail", "AAPL"])
+        assert result.exit_code != 0
+        assert "Failed to fetch detail for AAPL" in result.output
+
+
+# ---------------------------------------------------------------------------
+# format_show_table unit tests
+# ---------------------------------------------------------------------------
+
+
 class TestFormatShowTable:
     def test_columns_are_aligned(self):
         portfolio = Portfolio(

--- a/tests/test_show_detail.py
+++ b/tests/test_show_detail.py
@@ -1,0 +1,312 @@
+"""Tests for stonks_cli.show_detail (format_detail and helpers)."""
+
+from stonks_cli.show_detail import (
+    _analyst_section,
+    _eps_section,
+    _kv_table,
+    _performance_section,
+    _revenue_section,
+    _section,
+    format_detail,
+)
+from stonks_cli.stock_detail import StockDetail
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_MINIMAL = StockDetail(
+    symbol="AAPL",
+    name="Apple Inc.",
+    performance={
+        "YTD Return": ("+ 8.14%", "- 3.08%"),
+        "1-Year Return": ("+ 17.81%", "+ 18.16%"),
+    },
+    price_histories={},
+    summary={
+        "Previous Close": "150.00",
+        "Open": "151.00",
+        "Volume": "1,000,000",
+    },
+    eps_quarters=["Q1 FY25", "Q2 FY25"],
+    eps_actual=[1.50, 1.60],
+    eps_estimate=[1.45, 1.55],
+    eps_diff=[0.05, 0.05],
+    next_earnings_date="Apr 30, 2025",
+    next_eps_estimate=1.70,
+    rev_quarters=["Q1 FY25", "Q2 FY25"],
+    rev_values=[90.0, 95.0],
+    earn_values=[25.0, 27.0],
+    price_targets={"low": 140.0, "mean": 180.0, "high": 220.0},
+    recommendations=[],
+    recommendation_key="buy",
+    num_analysts=36,
+    valuation={"Trailing P/E": "32.50"},
+    financials={"Profit Margin": "25.50%"},
+)
+
+_EMPTY = StockDetail(
+    symbol="UNKNOWN",
+    name="UNKNOWN",
+    performance={},
+    price_histories={},
+    summary={},
+    eps_quarters=[],
+    eps_actual=[],
+    eps_estimate=[],
+    eps_diff=[],
+    next_earnings_date="N/A",
+    next_eps_estimate=None,
+    rev_quarters=[],
+    rev_values=[],
+    earn_values=[],
+    price_targets={},
+    recommendations=[],
+    recommendation_key="N/A",
+    num_analysts=0,
+    valuation={},
+    financials={},
+)
+
+
+# ---------------------------------------------------------------------------
+# _section
+# ---------------------------------------------------------------------------
+
+
+class TestSection:
+    def test_contains_title(self):
+        out = _section("Summary")
+        assert "Summary" in out
+
+    def test_underline_matches_title_length(self):
+        title = "Analyst Ratings"
+        out = _section(title)
+        lines = out.strip().split("\n")
+        assert len(lines) == 2
+        assert len(lines[1]) == len(title)
+
+    def test_starts_with_newline(self):
+        assert _section("X").startswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# _kv_table
+# ---------------------------------------------------------------------------
+
+
+class TestKvTable:
+    def test_empty_returns_empty_string(self):
+        assert _kv_table([]) == ""
+
+    def test_single_row(self):
+        out = _kv_table([("Key", "Value")])
+        assert "Key" in out
+        assert "Value" in out
+
+    def test_keys_aligned(self):
+        rows = [("Short", "v1"), ("A Long Key", "v2")]
+        out = _kv_table(rows)
+        lines = out.split("\n")
+        # Both lines should have the same length (keys padded to equal width)
+        assert len(lines) == 2
+        assert len(lines[0]) == len(lines[1])
+
+    def test_default_indent_two_spaces(self):
+        out = _kv_table([("K", "V")])
+        assert out.startswith("  ")
+
+    def test_custom_indent(self):
+        out = _kv_table([("K", "V")], indent=4)
+        assert out.startswith("    ")
+
+
+# ---------------------------------------------------------------------------
+# _performance_section
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceSection:
+    def test_empty_performance_returns_empty(self):
+        assert _performance_section(_EMPTY) == ""
+
+    def test_contains_symbol(self):
+        out = _performance_section(_MINIMAL)
+        assert "AAPL" in out
+
+    def test_contains_sp500_header(self):
+        out = _performance_section(_MINIMAL)
+        assert "S&P 500" in out
+
+    def test_contains_all_labels(self):
+        out = _performance_section(_MINIMAL)
+        assert "YTD Return" in out
+        assert "1-Year Return" in out
+
+    def test_contains_return_values(self):
+        out = _performance_section(_MINIMAL)
+        assert "+ 8.14%" in out
+        assert "- 3.08%" in out
+
+    def test_contains_section_header(self):
+        out = _performance_section(_MINIMAL)
+        assert "Performance" in out
+
+
+# ---------------------------------------------------------------------------
+# _eps_section
+# ---------------------------------------------------------------------------
+
+
+class TestEpsSection:
+    def test_empty_eps_returns_empty(self):
+        assert _eps_section(_EMPTY) == ""
+
+    def test_contains_section_header(self):
+        out = _eps_section(_MINIMAL)
+        assert "EPS" in out
+
+    def test_contains_quarters(self):
+        out = _eps_section(_MINIMAL)
+        assert "Q1 FY25" in out
+        assert "Q2 FY25" in out
+
+    def test_actual_and_estimate_shown(self):
+        out = _eps_section(_MINIMAL)
+        assert "1.50" in out
+        assert "1.45" in out
+
+    def test_diff_shown_with_sign(self):
+        out = _eps_section(_MINIMAL)
+        assert "+0.05" in out
+
+    def test_none_values_shown_as_na(self):
+        detail = StockDetail(
+            **{
+                **_MINIMAL.__dict__,
+                "eps_actual": [None, 1.60],
+                "eps_estimate": [None, 1.55],
+                "eps_diff": [None, 0.05],
+            }
+        )
+        out = _eps_section(detail)
+        assert "N/A" in out
+
+
+# ---------------------------------------------------------------------------
+# _revenue_section
+# ---------------------------------------------------------------------------
+
+
+class TestRevenueSection:
+    def test_empty_revenue_returns_empty(self):
+        assert _revenue_section(_EMPTY) == ""
+
+    def test_contains_section_header(self):
+        out = _revenue_section(_MINIMAL)
+        assert "Revenue" in out
+
+    def test_contains_quarters(self):
+        out = _revenue_section(_MINIMAL)
+        assert "Q1 FY25" in out
+        assert "Q2 FY25" in out
+
+    def test_revenue_values_shown(self):
+        out = _revenue_section(_MINIMAL)
+        assert "90.00" in out
+        assert "95.00" in out
+
+    def test_net_income_values_shown(self):
+        out = _revenue_section(_MINIMAL)
+        assert "25.00" in out
+        assert "27.00" in out
+
+
+# ---------------------------------------------------------------------------
+# _analyst_section
+# ---------------------------------------------------------------------------
+
+
+class TestAnalystSection:
+    def test_contains_recommendation(self):
+        out = _analyst_section(_MINIMAL)
+        assert "Buy" in out  # .title() applied
+
+    def test_contains_analyst_count(self):
+        out = _analyst_section(_MINIMAL)
+        assert "36" in out
+
+    def test_contains_price_targets(self):
+        out = _analyst_section(_MINIMAL)
+        assert "140.00" in out
+        assert "180.00" in out
+        assert "220.00" in out
+
+    def test_section_header_present(self):
+        out = _analyst_section(_MINIMAL)
+        assert "Analyst Ratings" in out
+
+    def test_unknown_key_title_case(self):
+        detail = StockDetail(
+            **{**_MINIMAL.__dict__, "recommendation_key": "strong buy"}
+        )
+        out = _analyst_section(detail)
+        assert "Strong Buy" in out
+
+    def test_missing_targets_omitted(self):
+        detail = StockDetail(**{**_MINIMAL.__dict__, "price_targets": {}})
+        out = _analyst_section(detail)
+        assert "Target" not in out
+
+
+# ---------------------------------------------------------------------------
+# format_detail
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetail:
+    def test_header_contains_symbol_and_name(self):
+        out = format_detail(_MINIMAL)
+        assert "AAPL" in out
+        assert "Apple Inc." in out
+
+    def test_all_sections_present_for_minimal(self):
+        out = format_detail(_MINIMAL)
+        assert "Summary" in out
+        assert "Performance" in out
+        assert "EPS" in out
+        assert "Revenue" in out
+        assert "Analyst Ratings" in out
+        assert "Valuation" in out
+        assert "Financials" in out
+
+    def test_empty_detail_skips_optional_sections(self):
+        out = format_detail(_EMPTY)
+        assert "UNKNOWN" in out
+        # No optional sections when data is empty
+        assert "Performance" not in out
+        assert "EPS" not in out
+        assert "Revenue" not in out
+        assert "Valuation" not in out
+        assert "Financials" not in out
+
+    def test_summary_key_values_present(self):
+        out = format_detail(_MINIMAL)
+        assert "Previous Close" in out
+        assert "150.00" in out
+
+    def test_valuation_section_shown_when_present(self):
+        out = format_detail(_MINIMAL)
+        assert "Trailing P/E" in out
+        assert "32.50" in out
+
+    def test_financials_section_shown_when_present(self):
+        out = format_detail(_MINIMAL)
+        assert "Profit Margin" in out
+        assert "25.50%" in out
+
+    def test_no_empty_lines_between_sections(self):
+        """format_detail filters out empty parts."""
+        out = format_detail(_EMPTY)
+        # Should not have consecutive blank lines (empty strings filtered)
+        assert "\n\n\n" not in out


### PR DESCRIPTION
Adds a new CLI command that prints a plain-text financial summary for a single ticker to stdout, mirroring how stonks show replaced the TUI dashboard for portfolio snapshots.