### PR TITLE
feat(cli): introduce stonks feed SYMBOL command

### DIFF
--- a/src/stonks_cli/main.py
+++ b/src/stonks_cli/main.py
@@ -212,6 +212,23 @@ def detail(symbol: str) -> None:
     click.echo(format_detail(d))
 
 
+@main.command()
+@click.argument("symbol")
+@click.option(
+    "--count", default=10, show_default=True, help="Number of articles to fetch."
+)
+def feed(symbol: str, count: int) -> None:
+    """Print the latest news articles for SYMBOL to stdout."""
+    from stonks_cli.news_fetcher import NewsFetcher
+    from stonks_cli.show_news import format_news
+
+    try:
+        items = NewsFetcher().fetch(symbol, limit=count)
+    except Exception as exc:
+        raise click.ClickException(f"Failed to fetch news for {symbol.upper()}: {exc}")
+    click.echo(format_news(symbol, items))
+
+
 @main.command("list")
 def list_portfolios() -> None:
     """List all portfolios in ~/.config/stonks/."""

--- a/src/stonks_cli/news_fetcher.py
+++ b/src/stonks_cli/news_fetcher.py
@@ -1,0 +1,97 @@
+"""yfinance-backed news fetcher for the ``feed`` command."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import yfinance as yf
+
+
+@dataclass
+class NewsItem:
+    headline: str
+    source: str
+    published_at: str  # formatted local time
+    url: str
+    timestamp: int = field(default=0, compare=False)
+
+
+class NewsFetcher:
+    """Fetches the latest company news for a symbol via yfinance."""
+
+    _MAX_ITEMS = 10
+
+    @staticmethod
+    def _parse_item(raw: dict) -> NewsItem | None:
+        content = raw.get("content", {})
+        if not isinstance(content, dict):
+            return None
+        headline = (content.get("title") or "").strip()
+        if not headline:
+            return None
+        url = (
+            (content.get("canonicalUrl") or {}).get("url")
+            or (content.get("clickThroughUrl") or {}).get("url")
+            or ""
+        ).strip()
+        source = ((content.get("provider") or {}).get("displayName") or "").strip()
+        pub_date = content.get("pubDate") or ""
+        ts = 0
+        published = "N/A"
+        if pub_date:
+            try:
+                dt = datetime.fromisoformat(pub_date.replace("Z", "+00:00"))
+                ts = int(dt.timestamp())
+                published = dt.astimezone().strftime("%b %d, %Y  %H:%M")
+            except (ValueError, OSError):
+                pass
+        return NewsItem(
+            headline=headline,
+            source=source,
+            published_at=published,
+            url=url,
+            timestamp=ts,
+        )
+
+    def fetch(self, symbol: str, limit: int | None = None) -> list[NewsItem]:
+        limit = self._MAX_ITEMS if limit is None else limit
+        raw_list = yf.Ticker(symbol.upper()).news or []
+        seen_urls: set[str] = set()
+        items: list[NewsItem] = []
+        for raw in raw_list:
+            item = self._parse_item(raw)
+            if item is None:
+                continue
+            if item.url:
+                if item.url in seen_urls:
+                    continue
+                seen_urls.add(item.url)
+            items.append(item)
+        items.sort(key=lambda x: x.timestamp, reverse=True)
+        return items[:limit]
+
+    def fetch_for_symbols(
+        self, symbols: list[str], max_items: int = 10
+    ) -> list[NewsItem]:
+        """Fetch, deduplicate, and sort news across all symbols.
+
+        Returns the *max_items* most recent unique articles sorted by
+        timestamp descending.
+        """
+        unique_symbols = sorted({s.upper() for s in symbols})
+        seen_urls: set[str] = set()
+        all_items: list[NewsItem] = []
+
+        with ThreadPoolExecutor() as executor:
+            futures = {
+                executor.submit(self.fetch, sym, max_items): sym
+                for sym in unique_symbols
+            }
+            for future in as_completed(futures):
+                for item in future.result():
+                    if item.url and item.url not in seen_urls:
+                        seen_urls.add(item.url)
+                        all_items.append(item)
+
+        all_items.sort(key=lambda x: x.timestamp, reverse=True)
+        return all_items[:max_items]

--- a/src/stonks_cli/show_news.py
+++ b/src/stonks_cli/show_news.py
@@ -1,0 +1,36 @@
+"""CLI formatted output for the ``feed`` command and dashboard panel."""
+
+from stonks_cli.news_fetcher import NewsItem
+
+
+def format_news(symbol: str, items: list[NewsItem]) -> str:
+    """Build a plain-text news feed for *symbol*."""
+    if not items:
+        return f"No recent news found for {symbol.upper()}."
+
+    header = f"Latest news: {symbol.upper()}"
+    lines = [header, "=" * len(header)]
+    for item in items:
+        lines.append(f"\n{item.headline}")
+        lines.append(f"   {item.source}  --  {item.published_at}")
+        lines.append(f"   {item.url}")
+    return "\n".join(lines)
+
+
+def format_news_panel(items: list[NewsItem]) -> str:
+    """Build Rich-markup text for the dashboard news panel.
+
+    Each item occupies two lines: headline on the first, source/time/URL
+    (dimmed) on the second.
+    """
+    header = "[bold]News[/bold]"
+    if not items:
+        return f"{header}\n  [dim]No recent news.[/dim]"
+
+    lines = [header]
+    for item in items:
+        lines.append(f"  {item.headline}")
+        lines.append(
+            f"[dim]    {item.source}  --  {item.published_at}  --  {item.url}[/dim]"
+        )
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -675,6 +675,37 @@ class TestDetail:
 
 
 # ---------------------------------------------------------------------------
+# feed
+# ---------------------------------------------------------------------------
+
+
+class TestFeed:
+    @patch("stonks_cli.news_fetcher.NewsFetcher")
+    @patch("stonks_cli.show_news.format_news", return_value="AAPL news output")
+    def test_feed_prints_output(self, mock_fmt, mock_fetcher_cls, runner):
+        result = runner.invoke(main, ["feed", "AAPL"])
+        assert result.exit_code == 0
+        assert "AAPL news output" in result.output
+
+    @patch("stonks_cli.news_fetcher.NewsFetcher")
+    @patch("stonks_cli.show_news.format_news")
+    def test_feed_calls_fetcher_with_symbol(self, mock_fmt, mock_fetcher_cls, runner):
+        mock_fmt.return_value = "output"
+        runner.invoke(main, ["feed", "MSFT"])
+        mock_fetcher_cls.return_value.fetch.assert_called_once_with("MSFT", limit=10)
+
+    @patch("stonks_cli.news_fetcher.NewsFetcher")
+    @patch("stonks_cli.show_news.format_news")
+    def test_feed_fetch_error_shows_click_exception(
+        self, mock_fmt, mock_fetcher_cls, runner
+    ):
+        mock_fetcher_cls.return_value.fetch.side_effect = RuntimeError("timeout")
+        result = runner.invoke(main, ["feed", "AAPL"])
+        assert result.exit_code != 0
+        assert "Failed to fetch news for AAPL" in result.output
+
+
+# ---------------------------------------------------------------------------
 # format_show_table unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_news_fetcher.py
+++ b/tests/test_news_fetcher.py
@@ -1,0 +1,315 @@
+"""Unit tests for NewsFetcher."""
+
+from unittest.mock import patch
+
+from stonks_cli.news_fetcher import NewsFetcher, NewsItem
+
+_AAPL_ITEMS = [
+    NewsItem(
+        "Apple hits high", "Reuters", "Mar 31, 2026  09:00", "https://r.com/1", 1000
+    ),
+    NewsItem(
+        "Apple Q1 results", "Bloomberg", "Mar 30, 2026  14:00", "https://b.com/2", 900
+    ),
+]
+_NVDA_ITEMS = [
+    NewsItem(
+        "Nvidia beats estimates", "CNBC", "Mar 31, 2026  10:00", "https://c.com/3", 1100
+    ),
+    # duplicate URL -- should be deduplicated
+    NewsItem(
+        "Apple hits high", "Reuters", "Mar 31, 2026  09:00", "https://r.com/1", 1000
+    ),
+]
+
+_RAW_ARTICLE = {
+    "content": {
+        "title": "Apple hits all-time high",
+        "pubDate": "2026-03-31T09:00:00Z",
+        "provider": {"displayName": "Reuters"},
+        "canonicalUrl": {"url": "https://reuters.com/1"},
+    }
+}
+
+
+def _make_fetcher(symbol_map: dict) -> NewsFetcher:
+    fetcher = NewsFetcher()
+    fetcher.fetch = lambda sym, limit=None: symbol_map.get(sym.upper(), [])  # type: ignore[method-assign]
+    return fetcher
+
+
+class TestParseItem:
+    def test_parses_headline(self):
+        item = NewsFetcher._parse_item(_RAW_ARTICLE)
+        assert item is not None
+        assert item.headline == "Apple hits all-time high"
+
+    def test_parses_source(self):
+        item = NewsFetcher._parse_item(_RAW_ARTICLE)
+        assert item is not None
+        assert item.source == "Reuters"
+
+    def test_parses_url(self):
+        item = NewsFetcher._parse_item(_RAW_ARTICLE)
+        assert item is not None
+        assert item.url == "https://reuters.com/1"
+
+    def test_parses_timestamp(self):
+        item = NewsFetcher._parse_item(_RAW_ARTICLE)
+        assert item is not None
+        assert item.timestamp > 0
+
+    def test_parses_published_at_format(self):
+        item = NewsFetcher._parse_item(_RAW_ARTICLE)
+        assert item is not None
+        # Should not be the fallback "N/A"
+        assert item.published_at != "N/A"
+
+    def test_returns_none_for_missing_title(self):
+        assert NewsFetcher._parse_item({"content": {}}) is None
+
+    def test_returns_none_for_missing_content(self):
+        assert NewsFetcher._parse_item({}) is None
+
+    def test_returns_none_for_non_dict_content(self):
+        assert NewsFetcher._parse_item({"content": "not a dict"}) is None
+
+    def test_returns_none_for_empty_title(self):
+        raw = {"content": {"title": "   "}}
+        assert NewsFetcher._parse_item(raw) is None
+
+    def test_falls_back_to_click_through_url(self):
+        raw = {
+            "content": {
+                "title": "Test",
+                "pubDate": "2026-03-31T09:00:00Z",
+                "provider": {"displayName": "X"},
+                "clickThroughUrl": {"url": "https://click.com/1"},
+            }
+        }
+        item = NewsFetcher._parse_item(raw)
+        assert item is not None
+        assert item.url == "https://click.com/1"
+
+    def test_handles_missing_pub_date(self):
+        raw = {
+            "content": {
+                "title": "No date article",
+                "provider": {"displayName": "Reuters"},
+                "canonicalUrl": {"url": "https://reuters.com/1"},
+            }
+        }
+        item = NewsFetcher._parse_item(raw)
+        assert item is not None
+        assert item.published_at == "N/A"
+        assert item.timestamp == 0
+
+    def test_handles_invalid_pub_date(self):
+        raw = {
+            "content": {
+                "title": "Bad date",
+                "pubDate": "not-a-date",
+                "provider": {"displayName": "Reuters"},
+                "canonicalUrl": {"url": "https://reuters.com/1"},
+            }
+        }
+        item = NewsFetcher._parse_item(raw)
+        assert item is not None
+        assert item.published_at == "N/A"
+        assert item.timestamp == 0
+
+    def test_handles_missing_provider(self):
+        raw = {
+            "content": {
+                "title": "No source",
+                "pubDate": "2026-03-31T09:00:00Z",
+                "canonicalUrl": {"url": "https://reuters.com/1"},
+            }
+        }
+        item = NewsFetcher._parse_item(raw)
+        assert item is not None
+        assert item.source == ""
+
+    def test_handles_none_canonical_url(self):
+        raw = {
+            "content": {
+                "title": "No URL",
+                "pubDate": "2026-03-31T09:00:00Z",
+                "provider": {"displayName": "Reuters"},
+                "canonicalUrl": None,
+                "clickThroughUrl": None,
+            }
+        }
+        item = NewsFetcher._parse_item(raw)
+        assert item is not None
+        assert item.url == ""
+
+
+class TestFetch:
+    def test_calls_yfinance(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = [_RAW_ARTICLE]
+            fetcher = NewsFetcher()
+            items = fetcher.fetch("AAPL")
+        mock_ticker_cls.assert_called_once_with("AAPL")
+        assert len(items) == 1
+
+    def test_handles_empty_news(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = []
+            fetcher = NewsFetcher()
+            items = fetcher.fetch("AAPL")
+        assert items == []
+
+    def test_handles_none_news(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = None
+            fetcher = NewsFetcher()
+            items = fetcher.fetch("AAPL")
+        assert items == []
+
+    def test_skips_unparseable_items(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = [{"content": {}}, _RAW_ARTICLE]
+            fetcher = NewsFetcher()
+            items = fetcher.fetch("AAPL")
+        assert len(items) == 1
+        assert items[0].headline == "Apple hits all-time high"
+
+    def test_uppercases_symbol(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = []
+            fetcher = NewsFetcher()
+            fetcher.fetch("aapl")
+        mock_ticker_cls.assert_called_once_with("AAPL")
+
+    def test_sorted_by_timestamp_descending(self):
+        older = {
+            "content": {
+                "title": "Older article",
+                "pubDate": "2026-03-30T09:00:00Z",
+                "provider": {"displayName": "Reuters"},
+                "canonicalUrl": {"url": "https://reuters.com/old"},
+            }
+        }
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = [older, _RAW_ARTICLE]
+            items = NewsFetcher().fetch("AAPL")
+        assert items[0].headline == "Apple hits all-time high"
+        assert items[1].headline == "Older article"
+
+    def test_respects_default_limit(self):
+        many = [
+            {
+                "content": {
+                    "title": f"Article {i}",
+                    "pubDate": "2026-03-31T09:00:00Z",
+                    "provider": {"displayName": "Reuters"},
+                    "canonicalUrl": {"url": f"https://reuters.com/{i}"},
+                }
+            }
+            for i in range(15)
+        ]
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = many
+            items = NewsFetcher().fetch("AAPL")
+        assert len(items) <= NewsFetcher._MAX_ITEMS
+
+    def test_custom_limit(self):
+        many = [
+            {
+                "content": {
+                    "title": f"Article {i}",
+                    "pubDate": "2026-03-31T09:00:00Z",
+                    "provider": {"displayName": "Reuters"},
+                    "canonicalUrl": {"url": f"https://reuters.com/{i}"},
+                }
+            }
+            for i in range(15)
+        ]
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = many
+            items = NewsFetcher().fetch("AAPL", limit=3)
+        assert len(items) == 3
+
+    def test_parses_all_items_before_slicing(self):
+        """Invalid items should not consume the limit budget."""
+        invalid = {"content": {}}
+        valid = _RAW_ARTICLE
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            # 4 invalid + 1 valid; with limit=1 we should still get 1
+            mock_ticker_cls.return_value.news = [
+                invalid,
+                invalid,
+                invalid,
+                invalid,
+                valid,
+            ]
+            items = NewsFetcher().fetch("AAPL", limit=1)
+        assert len(items) == 1
+        assert items[0].headline == "Apple hits all-time high"
+
+    def test_deduplicates_by_url(self):
+        duplicate = dict(_RAW_ARTICLE)
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = [_RAW_ARTICLE, duplicate]
+            items = NewsFetcher().fetch("AAPL")
+        assert len(items) == 1
+
+    def test_zero_limit_returns_empty(self):
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            mock_ticker_cls.return_value.news = [_RAW_ARTICLE]
+            items = NewsFetcher().fetch("AAPL", limit=0)
+        assert items == []
+
+
+class TestFetchForSymbols:
+    def test_returns_merged_items(self):
+        fetcher = _make_fetcher({"AAPL": _AAPL_ITEMS, "NVDA": _NVDA_ITEMS})
+        items = fetcher.fetch_for_symbols(["AAPL", "NVDA"])
+        headlines = [i.headline for i in items]
+        assert "Apple hits high" in headlines
+        assert "Nvidia beats estimates" in headlines
+
+    def test_deduplicates_by_url(self):
+        fetcher = _make_fetcher({"AAPL": _AAPL_ITEMS, "NVDA": _NVDA_ITEMS})
+        items = fetcher.fetch_for_symbols(["AAPL", "NVDA"])
+        urls = [i.url for i in items]
+        assert len(urls) == len(set(urls))
+
+    def test_sorted_by_timestamp_descending(self):
+        fetcher = _make_fetcher({"AAPL": _AAPL_ITEMS, "NVDA": _NVDA_ITEMS})
+        items = fetcher.fetch_for_symbols(["AAPL", "NVDA"])
+        timestamps = [i.timestamp for i in items]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_respects_max_items(self):
+        fetcher = _make_fetcher({"AAPL": _AAPL_ITEMS, "NVDA": _NVDA_ITEMS})
+        items = fetcher.fetch_for_symbols(["AAPL", "NVDA"], max_items=2)
+        assert len(items) <= 2
+
+    def test_fetches_all_symbols(self):
+        import threading
+
+        calls: list[str] = []
+        lock = threading.Lock()
+        fetcher = _make_fetcher({})
+
+        def _fetch(sym, limit=None):  # type: ignore[misc]
+            with lock:
+                calls.append(sym)
+            return []
+
+        fetcher.fetch = _fetch  # type: ignore[method-assign]
+        fetcher.fetch_for_symbols(["A", "B", "C", "D", "E", "F"])
+        assert set(calls) == {"A", "B", "C", "D", "E", "F"}
+
+    def test_empty_symbols_returns_empty(self):
+        fetcher = _make_fetcher({})
+        assert fetcher.fetch_for_symbols([]) == []
+
+    def test_skips_items_without_url(self):
+        no_url = NewsItem("No URL article", "Reuters", "Mar 31, 2026  09:00", "", 500)
+        fetcher = _make_fetcher({"AAPL": [no_url, *_AAPL_ITEMS]})
+        items = fetcher.fetch_for_symbols(["AAPL"])
+        assert all(i.url for i in items)

--- a/tests/test_show_news.py
+++ b/tests/test_show_news.py
@@ -1,0 +1,78 @@
+"""Unit tests for show_news.format_news and format_news_panel."""
+
+from stonks_cli.news_fetcher import NewsItem
+from stonks_cli.show_news import format_news, format_news_panel
+
+_ITEMS = [
+    NewsItem(
+        headline="Apple hits all-time high",
+        source="Reuters",
+        published_at="Mar 31, 2026  09:00",
+        url="https://reuters.com/1",
+    ),
+    NewsItem(
+        headline="iPhone sales beat estimates",
+        source="Bloomberg",
+        published_at="Mar 30, 2026  14:30",
+        url="https://bloomberg.com/2",
+    ),
+]
+
+
+class TestFormatNews:
+    def test_header_contains_symbol(self):
+        out = format_news("aapl", _ITEMS)
+        assert "AAPL" in out
+
+    def test_empty_items_returns_no_news_message(self):
+        out = format_news("AAPL", [])
+        assert "No recent news" in out
+        assert "AAPL" in out
+
+    def test_multiple_items_shown(self):
+        out = format_news("AAPL", _ITEMS)
+        assert "Apple hits all-time high" in out
+        assert "iPhone sales beat estimates" in out
+
+    def test_headlines_shown(self):
+        out = format_news("AAPL", _ITEMS)
+        assert "Apple hits all-time high" in out
+        assert "iPhone sales beat estimates" in out
+
+    def test_source_shown(self):
+        out = format_news("AAPL", _ITEMS)
+        assert "Reuters" in out
+        assert "Bloomberg" in out
+
+    def test_published_at_shown(self):
+        out = format_news("AAPL", _ITEMS)
+        assert "Mar 31, 2026  09:00" in out
+
+    def test_url_shown(self):
+        out = format_news("AAPL", _ITEMS)
+        assert "https://reuters.com/1" in out
+        assert "https://bloomberg.com/2" in out
+
+
+class TestFormatNewsPanel:
+    def test_header_shown(self):
+        out = format_news_panel(_ITEMS)
+        assert "News" in out
+
+    def test_empty_items_returns_no_news_message(self):
+        out = format_news_panel([])
+        assert "No recent news" in out
+
+    def test_headlines_shown(self):
+        out = format_news_panel(_ITEMS)
+        assert "Apple hits all-time high" in out
+        assert "iPhone sales beat estimates" in out
+
+    def test_source_and_time_shown(self):
+        out = format_news_panel(_ITEMS)
+        assert "Reuters" in out
+        assert "Mar 31, 2026  09:00" in out
+
+    def test_url_shown(self):
+        out = format_news_panel(_ITEMS)
+        assert "https://reuters.com/1" in out


### PR DESCRIPTION
Add a new `feed` CLI command that fetches and prints the last 10 news articles for a given stock symbol. The motivation is to give users a quick way to check market-moving headlines for a specific ticker from the same tool they already use for portfolio management, without having to switch to a browser or another application.

News is sourced via yfinance (already a project dependency), so no extra API key or new dependency is required. Articles are deduplicated by URL, sorted by publication time and rendered as plain text with source, timestamp and a direct link to the full article.