### PR TITLE
fix(dockerfile): drop poetry.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN pip install --no-cache-dir --upgrade pip build poetry-core
 
 # Copy sources needed for wheel build
-COPY pyproject.toml poetry.lock README.md /app/
+COPY pyproject.toml README.md /app/
 COPY src /app/src
 
 # Build a wheel (do NOT use --no-isolation unless you really need it)


### PR DESCRIPTION
Drop poetry.lock file from Dockerfile, as it's not commited to the rep.

It was intentionally chosen to drop (initially it was there) and not to commit poetry.lock for this project, as people install it primarily from PyPI, where dependency resolution is handled on the user's machine based on the version ranges defined in pyproject.toml.

Additionally, the project is evolving quickly, and avoiding strict dependency locking reduces friction during development.

Fixes: https://github.com/igoropaniuk/stonks-cli/issues/73