### PR TITLE
ci: restrict workflows to main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: Sanity checks
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   tests:

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -2,7 +2,9 @@ name: Conventional Commits
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,5 +1,9 @@
 name: Markdown Linter
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Limit push and pull_request triggers to the main branch so CI jobs do not fire on every push to feature branches, reducing unnecessary Actions minutes.