### PR TITLE
Increase test coverage

### DIFF
--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -523,3 +523,65 @@ class TestRunBacktest:
         result = run_backtest(_one_stock_portfolio(), config)
         # start_amount + cashflows for 2021 and 2022
         assert result.total_contributions == pytest.approx(12000)
+
+    @patch("stonks_cli.backtest.yf.download")
+    def test_single_symbol_equals_benchmark(self, mock_download):
+        """Portfolio with single symbol == benchmark hits single-col path."""
+        portfolio = Portfolio(positions=[Position("SPY", 10, 400.0)])
+        config = _default_config(benchmark="SPY")
+        n = len(_DATES_3Y)
+        # Single-symbol download returns non-MultiIndex df
+        df = pd.DataFrame(
+            {"Close": [400.0] * n},
+            index=pd.DatetimeIndex(_DATES_3Y),
+        )
+        mock_download.return_value = df
+        result = run_backtest(portfolio, config)
+        assert len(result.dates) > 0
+
+    @patch("stonks_cli.backtest.yf.download")
+    def test_portfolio_initial_value_zero_yields_zero_annual_returns(
+        self, mock_download
+    ):
+        """When initial price is 0, portfolio_val is 0 -> covers zero annual returns."""
+        n = len(_DATES_3Y)
+        # Start with price=0 (shares=0), then non-zero -- portfolio_val starts at 0
+        prices = [0.0] + [150.0] * (n - 1)
+        spy_prices = [400.0] * n
+        df = _make_prices(_DATES_3Y, {"AAPL": prices, "SPY": spy_prices})
+        mock_download.return_value = pd.concat({"Close": df}, axis=1)
+        result = run_backtest(_one_stock_portfolio(), _default_config())
+        # Portfolio starts at 0 value so the first annual return must be 0.0
+        assert result.annual_portfolio_returns[0] == 0.0
+
+    @patch("stonks_cli.backtest.yf.download")
+    def test_benchmark_initial_price_zero_yields_zero_bench_returns(
+        self, mock_download
+    ):
+        """When benchmark starts at 0, bench shares=0 -> zero bench annual returns."""
+        n = len(_DATES_3Y)
+        # SPY starts at 0 (no purchase possible), then goes to 400
+        spy_prices = [0.0] + [400.0] * (n - 1)
+        aapl_prices = [150.0] * n
+        df = _make_prices(_DATES_3Y, {"AAPL": aapl_prices, "SPY": spy_prices})
+        mock_download.return_value = pd.concat({"Close": df}, axis=1)
+        result = run_backtest(_one_stock_portfolio(), _default_config())
+        assert result.annual_benchmark_returns[0] == 0.0
+
+
+class TestClosestDateIndexEdge:
+    def test_target_after_last_date_bisect_idx_at_end(self):
+        """When bisect returns idx == len(dates), we return len(dates)-1."""
+        from stonks_cli.chart import _closest_date_index
+
+        dates = ["2025-01-01", "2025-01-02"]
+        assert _closest_date_index(dates, "2025-01-10") == 1
+
+    def test_target_between_two_dates_returns_lower_neighbour(self):
+        """When target falls strictly between two dates, lower neighbour is returned."""
+        from stonks_cli.chart import _closest_date_index
+
+        dates = ["2025-01-01", "2025-01-03", "2025-01-07"]
+        # "2025-01-06" is closer to index 2 ("2025-01-07") but the implementation
+        # uses floor/bisect-left behaviour and returns the lower neighbour.
+        assert _closest_date_index(dates, "2025-01-06") == 1

--- a/tests/test_backtest_detail.py
+++ b/tests/test_backtest_detail.py
@@ -1,0 +1,519 @@
+"""Tests for the backtest detail screen."""
+
+from unittest.mock import patch
+
+import pytest
+from textual.widgets import Label
+
+from stonks_cli.app import PortfolioApp
+from stonks_cli.backtest import BacktestResult
+from stonks_cli.backtest_detail import BacktestScreen
+from stonks_cli.dto import BacktestConfig
+from stonks_cli.models import Portfolio, Position
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USD_RATES = {"USD": {"USD": 1.0}}
+
+_AAPL_POS = Position(symbol="AAPL", quantity=10, avg_cost=150.0)
+
+
+def _make_app() -> PortfolioApp:
+    portfolio = Portfolio(positions=[_AAPL_POS])
+    return PortfolioApp(
+        portfolios=[portfolio],
+        prices={"AAPL": 160.0},
+        forex_rates=USD_RATES,
+    )
+
+
+def _default_config(**overrides: object) -> BacktestConfig:
+    defaults: BacktestConfig = {
+        "benchmark": "SPY",
+        "start_amount": 10000,
+        "start_year": 2020,
+        "end_year": 2022,
+        "cashflows": 0,
+        "rebalance": "none",
+        "skip_unavailable": False,
+    }
+    defaults.update(overrides)  # type: ignore[typeddict-item]
+    return defaults
+
+
+def _minimal_result() -> BacktestResult:
+    """A result with enough data to exercise all rendering paths."""
+    return BacktestResult(
+        dates=["2020-01-02", "2020-06-15", "2021-01-04", "2021-06-15", "2022-01-03"],
+        portfolio_values=[10000.0, 11000.0, 12000.0, 13000.0, 14000.0],
+        benchmark_values=[10000.0, 10500.0, 11000.0, 11500.0, 12000.0],
+        annual_years=["2020", "2021"],
+        annual_portfolio_returns=[20.0, 16.7],
+        annual_benchmark_returns=[10.0, 9.1],
+        portfolio_cagr=18.3,
+        benchmark_cagr=9.5,
+        portfolio_max_drawdown=-5.2,
+        benchmark_max_drawdown=-3.1,
+        portfolio_sharpe=1.5,
+        benchmark_sharpe=0.9,
+        portfolio_best_year="2020 (+20.0%)",
+        portfolio_worst_year="2021 (+16.7%)",
+        benchmark_best_year="2020 (+10.0%)",
+        benchmark_worst_year="2021 (+9.1%)",
+        portfolio_final=14000.0,
+        benchmark_final=12000.0,
+        total_contributions=10000.0,
+        skipped_symbols=[],
+    )
+
+
+def _empty_result() -> BacktestResult:
+    """A result with minimal/empty data."""
+    return BacktestResult()
+
+
+def _result_with_skipped() -> BacktestResult:
+    """A result with skipped symbols."""
+    r = _minimal_result()
+    r.skipped_symbols = ["GOOG", "TSLA"]
+    return r
+
+
+_DEFAULT_PORTFOLIO = Portfolio(positions=[_AAPL_POS])
+_DEFAULT_CONFIG = _default_config()
+
+
+# ---------------------------------------------------------------------------
+# Compose / initial state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_screen_compose():
+    """BacktestScreen creates expected initial widgets."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        loading = screen.query_one("#loading")
+        assert loading is not None
+        error = screen.query_one("#error-msg", Label)
+        assert error is not None
+        scroll = screen.query_one("#bt-scroll")
+        assert scroll.display is False
+
+
+@pytest.mark.asyncio
+async def test_backtest_screen_title_shows_portfolio_and_config():
+    """Title and subtitle reflect portfolio name and config."""
+    app = _make_app()
+    portfolio = Portfolio(positions=[_AAPL_POS], name="My Portfolio")
+    config = _default_config(
+        start_year=2015, end_year=2025, start_amount=50000, cashflows=5000
+    )
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(portfolio, config)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        title = screen.query_one("#bt-title", Label)
+        assert "My Portfolio" in str(title.content)
+        assert "SPY" in str(title.content)
+
+        subtitle = screen.query_one("#bt-subtitle", Label)
+        sub_text = str(subtitle.content)
+        assert "2015" in sub_text
+        assert "2025" in sub_text
+        assert "50,000" in sub_text
+        assert "5,000" in sub_text
+
+
+@pytest.mark.asyncio
+async def test_backtest_screen_default_portfolio_name():
+    """When portfolio has no name, title falls back to 'Portfolio'."""
+    app = _make_app()
+    portfolio = Portfolio(positions=[_AAPL_POS])  # no name
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(portfolio, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        title = screen.query_one("#bt-title", Label)
+        assert "Portfolio" in str(title.content)
+
+
+# ---------------------------------------------------------------------------
+# Error display
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_screen_shows_error():
+    """_show_error hides loading and displays error message."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._show_error("No historical data")
+        await pilot.pause()
+
+        assert screen.query_one("#loading").display is False
+        err = screen.query_one("#error-msg", Label)
+        assert "No historical data" in str(err.content)
+
+
+# ---------------------------------------------------------------------------
+# _apply_result - full data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_result_shows_all_sections():
+    """_apply_result populates the scroll area with all sections."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_minimal_result())
+        await pilot.pause()
+
+        assert screen.query_one("#loading").display is False
+        assert screen.query_one("#bt-scroll").display is True
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert any("Portfolio Growth" in t for t in label_texts)
+        assert any("Annual Returns" in t for t in label_texts)
+        assert any("Backtest Summary" in t for t in label_texts)
+
+
+@pytest.mark.asyncio
+async def test_apply_result_empty_data():
+    """_apply_result with empty result shows summary but no charts."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_empty_result())
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        # Summary always rendered
+        assert any("Backtest Summary" in t for t in label_texts)
+        # Charts need data
+        assert not any("Portfolio Growth" in t for t in label_texts)
+        assert not any("Annual Returns" in t for t in label_texts)
+
+
+# ---------------------------------------------------------------------------
+# Skipped symbols
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_result_skipped_symbols():
+    """Skipped symbols are shown as a notice."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_result_with_skipped())
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert any("GOOG" in t and "TSLA" in t for t in label_texts)
+
+
+@pytest.mark.asyncio
+async def test_apply_result_no_skipped_symbols():
+    """When no symbols are skipped, no notice is shown."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_minimal_result())
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert not any("Skipped" in t for t in label_texts)
+
+
+# ---------------------------------------------------------------------------
+# Summary section values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_shows_portfolio_and_benchmark_stats():
+    """Summary section displays key stats for both portfolio and benchmark."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_minimal_result())
+        await pilot.pause()
+
+        statics = screen.query("Static")
+        texts = [str(s.content) for s in statics]
+        # Portfolio label
+        assert any("Portfolio" in t for t in texts)
+        # Benchmark label
+        assert any("SPY" in t for t in texts)
+        # Final values
+        assert any("14,000" in t for t in texts)
+        assert any("12,000" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# Downsample
+# ---------------------------------------------------------------------------
+
+
+class TestDownsample:
+    def test_no_downsample_when_within_limit(self):
+        values = [1.0, 2.0, 3.0]
+        dates = ["a", "b", "c"]
+        v, d = BacktestScreen._downsample(values, dates, max_points=10)
+        assert v == values
+        assert d == dates
+
+    def test_downsample_reduces_points(self):
+        n = 1000
+        values = list(range(n))
+        dates = [str(i) for i in range(n)]
+        v, d = BacktestScreen._downsample(values, dates, max_points=100)
+        assert len(v) == 101
+        assert len(v) == len(d)
+        # First and last values preserved
+        assert v[0] == 0
+        assert v[-1] == n - 1
+
+    def test_downsample_exact_boundary(self):
+        values = [1.0] * 500
+        dates = ["d"] * 500
+        v, d = BacktestScreen._downsample(values, dates, max_points=500)
+        assert len(v) == 500
+
+
+# ---------------------------------------------------------------------------
+# Worker thread integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_backtest_worker_success():
+    """Worker thread calls _apply_result on success."""
+    app = _make_app()
+    result = _minimal_result()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch("stonks_cli.backtest_detail.run_backtest", return_value=result):
+            with patch.object(screen, "_call_from_thread_if_running") as mock_call:
+                # Call the unwrapped worker function directly
+                BacktestScreen._run_backtest.__wrapped__(screen)
+                assert mock_call.called
+                # First call should be _apply_result
+                args = mock_call.call_args_list[0]
+                assert args[0][0] == screen._apply_result
+
+
+@pytest.mark.asyncio
+async def test_run_backtest_worker_error():
+    """Worker thread calls _show_error on failure."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch(
+            "stonks_cli.backtest_detail.run_backtest",
+            side_effect=ValueError("No data"),
+        ):
+            with patch.object(screen, "_call_from_thread_if_running") as mock_call:
+                BacktestScreen._run_backtest.__wrapped__(screen)
+                assert mock_call.called
+                args = mock_call.call_args_list[0]
+                assert args[0][0] == screen._show_error
+                assert "No data" in args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Growth chart rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_growth_chart_renders_with_data():
+    """Growth chart mounts when portfolio_values has data."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._apply_result(_minimal_result())
+        await pilot.pause()
+
+        from textual_plotext import PlotextPlot
+
+        charts = screen.query(PlotextPlot)
+        # At least growth + annual = 2 charts
+        assert len(charts) >= 2
+
+
+@pytest.mark.asyncio
+async def test_growth_chart_skipped_with_no_values():
+    """Growth chart not mounted when portfolio_values is empty."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        r = _empty_result()
+        screen._apply_result(r)
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert not any("Portfolio Growth" in t for t in label_texts)
+
+
+# ---------------------------------------------------------------------------
+# Annual chart rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annual_chart_skipped_with_no_years():
+    """Annual chart not mounted when annual_years is empty."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        r = _minimal_result()
+        r.annual_years = []
+        r.annual_portfolio_returns = []
+        r.annual_benchmark_returns = []
+        screen._apply_result(r)
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert not any("Annual Returns" in t for t in label_texts)
+
+
+@pytest.mark.asyncio
+async def test_annual_chart_with_zero_returns():
+    """Annual chart handles zero return values without error."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        r = _minimal_result()
+        r.annual_portfolio_returns = [0.0, 0.0]
+        r.annual_benchmark_returns = [0.0, 0.0]
+        screen._apply_result(r)
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        label_texts = [str(lb.content) for lb in labels]
+        assert any("Annual Returns" in t for t in label_texts)
+
+
+# ---------------------------------------------------------------------------
+# Scroll bindings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scroll_bindings_present():
+    """BacktestScreen has scroll bindings from SCROLL_BINDINGS."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        binding_actions = {b.action for b in screen.BINDINGS}
+        assert "scroll_up" in binding_actions
+        assert "scroll_down" in binding_actions
+        assert "page_up" in binding_actions
+        assert "page_down" in binding_actions
+        assert "app.pop_screen" in binding_actions
+
+
+@pytest.mark.asyncio
+async def test_escape_pops_backtest_screen():
+    """Pressing escape pops the backtest screen."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(_DEFAULT_PORTFOLIO, _DEFAULT_CONFIG)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        assert isinstance(app.screen, BacktestScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, BacktestScreen)

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from stonks_cli.app import PortfolioApp
 from stonks_cli.chart import (
     _Y_SCALE_STEP,
     _ZOOM_LEVELS,
@@ -553,3 +554,1105 @@ class TestZoomLevels:
     def test_all_refresh_seconds_positive(self):
         for level in _ZOOM_LEVELS:
             assert level[4] > 0
+
+
+# ---------------------------------------------------------------------------
+# _CandleData methods: _ohlcv_fields, prepend, append_from
+# ---------------------------------------------------------------------------
+
+
+def _make_candle_data(n: int = 3, start_close: float = 100.0) -> _CandleData:
+    return _CandleData(
+        dates=[f"2025-03-{i + 1:02d} 09:30" for i in range(n)],
+        opens=[start_close] * n,
+        highs=[start_close + 5] * n,
+        lows=[start_close - 2] * n,
+        closes=[start_close + 1] * n,
+        volumes=[1000.0 * (i + 1) for i in range(n)],
+    )
+
+
+class TestCandleDataMethods:
+    def test_ohlcv_fields_returns_all_six_lists(self):
+        data = _make_candle_data(2)
+        fields = data._ohlcv_fields()
+        assert len(fields) == 6
+        assert fields[0] is data.dates
+        assert fields[5] is data.volumes
+
+    def test_prepend_adds_candles_at_front(self):
+        data = _make_candle_data(3)
+        older = _CandleData(
+            dates=["2025-02-26 09:30", "2025-02-27 09:30"],
+            opens=[90.0, 91.0],
+            highs=[95.0, 96.0],
+            lows=[88.0, 89.0],
+            closes=[92.0, 93.0],
+            volumes=[500.0, 600.0],
+        )
+        data.prepend(older, 2)
+        assert data.dates[0] == "2025-02-26 09:30"
+        assert data.dates[1] == "2025-02-27 09:30"
+        assert len(data.dates) == 5
+
+    def test_prepend_with_n_less_than_other_length(self):
+        data = _make_candle_data(3)
+        older = _CandleData(
+            dates=["2025-02-25 09:30", "2025-02-26 09:30"],
+            opens=[90.0, 91.0],
+            highs=[95.0, 96.0],
+            lows=[88.0, 89.0],
+            closes=[92.0, 93.0],
+            volumes=[500.0, 600.0],
+        )
+        data.prepend(older, 1)  # only prepend first 1
+        assert data.dates[0] == "2025-02-25 09:30"
+        assert len(data.dates) == 4
+
+    def test_append_from_adds_candles_at_end(self):
+        data = _make_candle_data(2)
+        new_candles = [
+            ("2025-03-10 09:30", 105.0, 110.0, 103.0, 108.0, 2000.0),
+            ("2025-03-11 09:30", 108.0, 112.0, 106.0, 111.0, 2100.0),
+        ]
+        data.append_from(new_candles)
+        assert data.dates[-1] == "2025-03-11 09:30"
+        assert len(data.dates) == 4
+        assert data.closes[-1] == 111.0
+
+    def test_append_from_empty_list_no_change(self):
+        data = _make_candle_data(2)
+        original_len = len(data)
+        data.append_from([])
+        assert len(data) == original_len
+
+
+# ---------------------------------------------------------------------------
+# _draw_candles -- pure function, uses a mock plt
+# ---------------------------------------------------------------------------
+
+
+class TestDrawCandles:
+    def _make_plt(self):
+        plt = MagicMock()
+        return plt
+
+    def test_draw_candles_calls_plot_for_up_candles(self):
+        from stonks_cli.chart import _draw_candles
+
+        data = _CandleData(
+            dates=["2025-03-01 09:30"],
+            opens=[100.0],
+            highs=[105.0],
+            lows=[98.0],
+            closes=[102.0],  # close > open => up candle
+            volumes=[1000.0],
+        )
+        plt = self._make_plt()
+        _draw_candles(plt, data)
+        assert plt.plot.called
+
+    def test_draw_candles_calls_plot_for_down_candles(self):
+        from stonks_cli.chart import _draw_candles
+
+        data = _CandleData(
+            dates=["2025-03-01 09:30"],
+            opens=[105.0],
+            highs=[107.0],
+            lows=[98.0],
+            closes=[99.0],  # close < open => down candle
+            volumes=[1000.0],
+        )
+        plt = self._make_plt()
+        _draw_candles(plt, data)
+        assert plt.plot.called
+
+    def test_draw_candles_mixed_up_and_down(self):
+        from stonks_cli.chart import _draw_candles
+
+        data = _CandleData(
+            dates=["2025-03-01 09:30", "2025-03-02 09:30"],
+            opens=[100.0, 105.0],
+            highs=[107.0, 110.0],
+            lows=[98.0, 99.0],
+            closes=[104.0, 102.0],  # up, then down
+            volumes=[1000.0, 2000.0],
+        )
+        plt = self._make_plt()
+        _draw_candles(plt, data)
+        # Should have called plot multiple times (wicks + bodies)
+        assert plt.plot.call_count >= 2
+
+    def test_draw_candles_empty_data_no_plot(self):
+        from stonks_cli.chart import _draw_candles
+
+        data = _CandleData()
+        plt = self._make_plt()
+        _draw_candles(plt, data)
+        plt.plot.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_candles with start/end date range
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCandlesWithDateRange:
+    @pytest.fixture(autouse=True)
+    def _mock_yf(self):
+        with patch("stonks_cli.chart.yf.Ticker") as mock_cls:
+            self.mock_ticker = MagicMock()
+            mock_cls.return_value = self.mock_ticker
+            yield
+
+    def _make_hist(self, n=2):
+        idx = pd.date_range("2025-03-01", periods=n, freq="1D", tz="UTC")
+        return pd.DataFrame(
+            {
+                "Open": [100.0] * n,
+                "High": [105.0] * n,
+                "Low": [98.0] * n,
+                "Close": [102.0] * n,
+                "Volume": [1000.0] * n,
+            },
+            index=idx,
+        )
+
+    def test_fetch_with_start_and_end(self):
+        self.mock_ticker.history.return_value = self._make_hist(2)
+        data = _fetch_candles("AAPL", "1y", "1d", start="2025-03-01", end="2025-03-03")
+        assert len(data) == 2
+        assert data.last == 102.0
+
+    def test_fetch_with_start_and_end_sets_last(self):
+        """data.last is set when closes are non-empty."""
+        self.mock_ticker.history.return_value = self._make_hist(3)
+        data = _fetch_candles("AAPL", "1y", "1d", start="2025-01-01", end="2025-04-01")
+        assert data.last == 102.0
+
+
+# ---------------------------------------------------------------------------
+# _prepend_data and _append_data (pure unit tests, no app)
+# ---------------------------------------------------------------------------
+
+
+class TestPrependData:
+    def _make_screen(self) -> CandleChartScreen:
+        screen = CandleChartScreen("AAPL")
+        screen._data = _make_candle_data(3)
+        return screen
+
+    def test_prepend_data_adds_older_candles(self):
+        screen = self._make_screen()
+        older = _CandleData(
+            dates=["2025-02-26 09:30", "2025-02-27 09:30"],
+            opens=[90.0, 91.0],
+            highs=[95.0, 96.0],
+            lows=[88.0, 89.0],
+            closes=[92.0, 93.0],
+            volumes=[500.0, 600.0],
+        )
+        with patch.object(screen, "_redraw"):
+            screen._prepend_data(older)
+        assert screen._data.dates[0] == "2025-02-26 09:30"
+        assert screen._prefetching is False
+
+    def test_prepend_data_shifts_cursor(self):
+        screen = self._make_screen()
+        screen._cursor = 1
+        older = _CandleData(
+            dates=["2025-02-26 09:30"],
+            opens=[90.0],
+            highs=[95.0],
+            lows=[88.0],
+            closes=[92.0],
+            volumes=[500.0],
+        )
+        with patch.object(screen, "_redraw"):
+            screen._prepend_data(older)
+        assert screen._cursor == 2  # shifted by n_new=1
+
+    def test_prepend_data_no_change_if_no_new_dates_before_current(self):
+        screen = self._make_screen()
+        original_first = screen._data.dates[0]
+        later = _CandleData(
+            dates=["2025-03-10 09:30"],  # after current first date
+            opens=[110.0],
+            highs=[115.0],
+            lows=[108.0],
+            closes=[112.0],
+            volumes=[500.0],
+        )
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._prepend_data(later)
+        mock_redraw.assert_not_called()
+        assert screen._data.dates[0] == original_first
+
+    def test_prepend_data_empty_new_data(self):
+        screen = self._make_screen()
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._prepend_data(_CandleData())
+        mock_redraw.assert_not_called()
+
+    def test_prepend_data_empty_existing_data(self):
+        screen = CandleChartScreen("AAPL")
+        screen._data = _CandleData()
+        older = _make_candle_data(2)
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._prepend_data(older)
+        mock_redraw.assert_not_called()
+
+
+class TestAppendData:
+    def _make_screen(self) -> CandleChartScreen:
+        screen = CandleChartScreen("AAPL")
+        screen._data = _make_candle_data(3)
+        return screen
+
+    def test_append_data_adds_newer_candles(self):
+        screen = self._make_screen()
+        newer = _CandleData(
+            dates=["2025-03-10 09:30", "2025-03-11 09:30"],
+            opens=[110.0, 111.0],
+            highs=[115.0, 116.0],
+            lows=[108.0, 109.0],
+            closes=[112.0, 113.0],
+            volumes=[1500.0, 1600.0],
+        )
+        with patch.object(screen, "_redraw"):
+            screen._append_data(newer)
+        assert "2025-03-10 09:30" in screen._data.dates
+        assert screen._prefetching is False
+
+    def test_append_data_deduplicates_dates(self):
+        """Candles with dates at or before the current last are excluded."""
+        screen = self._make_screen()
+        last_date = screen._data.dates[-1]
+        # These candles overlap with existing data
+        overlap = _CandleData(
+            dates=[last_date, "2025-03-10 09:30"],  # first is duplicate
+            opens=[100.0, 110.0],
+            highs=[105.0, 115.0],
+            lows=[98.0, 108.0],
+            closes=[102.0, 112.0],
+            volumes=[1000.0, 1500.0],
+        )
+        orig_len = len(screen._data)
+        with patch.object(screen, "_redraw"):
+            screen._append_data(overlap)
+        # Only "2025-03-10" should have been added
+        assert len(screen._data) == orig_len + 1
+
+    def test_append_data_empty_new_data(self):
+        screen = self._make_screen()
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._append_data(_CandleData())
+        mock_redraw.assert_not_called()
+
+    def test_append_data_empty_existing_data(self):
+        screen = CandleChartScreen("AAPL")
+        screen._data = _CandleData()
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._append_data(_make_candle_data(2))
+        mock_redraw.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _maybe_prefetch_history / _maybe_prefetch_future
+# ---------------------------------------------------------------------------
+
+
+class TestMaybePrefetch:
+    def _screen_with_historical_zoom(self) -> CandleChartScreen:
+        """Return a screen at a zoom level that supports historical intervals."""
+        from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+        screen = CandleChartScreen("AAPL")
+        # Find a zoom level using a historical interval
+        for idx, level in enumerate(_ZOOM_LEVELS):
+            if level[2] in _HISTORICAL_INTERVALS:
+                screen._zoom_idx = idx
+                break
+        screen._data = _make_candle_data(5)
+        return screen
+
+    def _screen_with_non_historical_zoom(self) -> CandleChartScreen:
+        """Return a screen at a zoom level without historical interval support."""
+        from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+        screen = CandleChartScreen("AAPL")
+        for idx, level in enumerate(_ZOOM_LEVELS):
+            if level[2] not in _HISTORICAL_INTERVALS:
+                screen._zoom_idx = idx
+                break
+        screen._data = _make_candle_data(5)
+        return screen
+
+    def test_maybe_prefetch_history_non_historical_interval_skips(self):
+        screen = self._screen_with_non_historical_zoom()
+        with patch.object(screen, "_prefetch_history") as mock_pf:
+            screen._maybe_prefetch_history()
+        mock_pf.assert_not_called()
+
+    def test_maybe_prefetch_history_already_prefetching_skips(self):
+        screen = self._screen_with_historical_zoom()
+        screen._prefetching = True
+        with patch.object(screen, "_prefetch_history") as mock_pf:
+            screen._maybe_prefetch_history()
+        mock_pf.assert_not_called()
+
+    def test_maybe_prefetch_history_starts_prefetch(self):
+        screen = self._screen_with_historical_zoom()
+        screen._prefetching = False
+        with patch.object(screen, "_prefetch_history") as mock_pf:
+            screen._maybe_prefetch_history()
+        assert screen._prefetching is True
+        mock_pf.assert_called_once()
+
+    def test_maybe_prefetch_future_non_historical_interval_skips(self):
+        screen = self._screen_with_non_historical_zoom()
+        with patch.object(screen, "_prefetch_future") as mock_pf:
+            screen._maybe_prefetch_future()
+        mock_pf.assert_not_called()
+
+    def test_maybe_prefetch_future_already_prefetching_skips(self):
+        screen = self._screen_with_historical_zoom()
+        screen._prefetching = True
+        with patch.object(screen, "_prefetch_future") as mock_pf:
+            screen._maybe_prefetch_future()
+        mock_pf.assert_not_called()
+
+    def test_maybe_prefetch_future_starts_prefetch(self):
+        screen = self._screen_with_historical_zoom()
+        screen._prefetching = False
+        with patch.object(screen, "_prefetch_future") as mock_pf:
+            screen._maybe_prefetch_future()
+        assert screen._prefetching is True
+        mock_pf.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CandleChartScreen TUI tests (compose, on_resize, _apply_bid_ask, _redraw)
+# ---------------------------------------------------------------------------
+
+
+def _make_app_for_chart() -> PortfolioApp:
+    from stonks_cli.models import Portfolio, Position
+
+    portfolio = Portfolio(positions=[Position("AAPL", 10, 150.0)])
+    return PortfolioApp(
+        portfolios=[portfolio],
+        prices={"AAPL": 160.0},
+        forex_rates={"USD": {"USD": 1.0}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_screen_compose():
+    """CandleChartScreen composes its expected widgets."""
+    from textual.widgets import Label
+
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        assert screen.query_one("#chart-title", Label) is not None
+        assert screen.query_one("#ohlc-bar") is not None
+        assert screen.query_one("#candle-chart") is not None
+        assert screen.query_one("#zoom-label") is not None
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_apply_bid_ask():
+    """_apply_bid_ask updates _data bid/ask and triggers redraw."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen._apply_bid_ask(101.5, 102.5)
+
+        assert screen._data.bid == 101.5
+        assert screen._data.ask == 102.5
+        mock_redraw.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_redraw_with_data():
+    """_redraw runs without error when data is populated."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        # Populate data and call _redraw
+        screen._data = _make_candle_data(5)
+        screen._data.bid = 101.0
+        screen._data.ask = 102.0
+        screen._data.last = 101.5
+        screen._redraw()
+        await pilot.pause()
+
+        from textual.widgets import Static
+
+        ohlc = screen.query_one("#ohlc-bar", Static)
+        assert "O:" in str(ohlc.content)
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_redraw_empty_data_no_crash():
+    """_redraw does nothing when data is empty."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        # Should not raise
+        screen._redraw()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_on_resize():
+    """on_resize triggers _redraw."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen.on_resize()
+
+        mock_redraw.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_cursor_left_at_end_triggers_prefetch():
+    """cursor_left at position 0 triggers _maybe_prefetch_history."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 0  # already at leftmost
+
+        with (
+            patch.object(screen, "_maybe_prefetch_history") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_left()
+
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_cursor_right_at_end_triggers_prefetch():
+    """cursor_right at last position triggers _maybe_prefetch_future."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 4  # already at rightmost
+
+        with (
+            patch.object(screen, "_maybe_prefetch_future") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_right()
+
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_cursor_home_triggers_prefetch():
+    """action_cursor_home triggers _maybe_prefetch_history."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 4
+
+        with (
+            patch.object(screen, "_maybe_prefetch_history") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_home()
+
+        assert screen._cursor == 0
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_cursor_end_triggers_prefetch():
+    """action_cursor_end triggers _maybe_prefetch_future."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 2
+
+        with (
+            patch.object(screen, "_maybe_prefetch_future") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_end()
+
+        assert screen._cursor == -1
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_cursor_left_when_empty():
+    """cursor_left on empty data does nothing."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        # data is empty
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen.action_cursor_left()
+        mock_redraw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_worker_thread_load_data_success():
+    """_load_data worker calls _apply_data on success."""
+    app = _make_app_for_chart()
+    result_data = _make_candle_data(5)
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch("stonks_cli.chart._fetch_candles", return_value=result_data):
+            with patch.object(screen, "_call_from_thread_if_running") as mock_call:
+                CandleChartScreen._load_data.__wrapped__(screen)
+                assert mock_call.called
+                args = mock_call.call_args_list[0]
+                assert args[0][0] == screen._apply_data
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_worker_thread_load_data_error():
+    """_load_data worker returns early on exception without calling _apply_data."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        err = RuntimeError("network")
+        with patch("stonks_cli.chart._fetch_candles", side_effect=err):
+            with patch.object(screen, "_call_from_thread_if_running") as mock_call:
+                CandleChartScreen._load_data.__wrapped__(screen)
+                mock_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_prefetch_history_worker_empty_data():
+    """_prefetch_history worker resets _prefetching when data is empty."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _CandleData()  # empty
+        screen._prefetching = True
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        with patch.object(screen, cftir, side_effect=record_call):
+            CandleChartScreen._prefetch_history.__wrapped__(screen)
+
+        # Should have called setattr to reset _prefetching
+        assert any(fn == setattr for fn, _ in calls)
+
+
+@pytest.mark.asyncio
+async def test_candle_chart_prefetch_future_worker_empty_data():
+    """_prefetch_future worker resets _prefetching when data is empty."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _CandleData()  # empty
+        screen._prefetching = True
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        with patch.object(screen, cftir, side_effect=record_call):
+            CandleChartScreen._prefetch_future.__wrapped__(screen)
+
+        assert any(fn == setattr for fn, _ in calls)
+
+
+# ---------------------------------------------------------------------------
+# _restart_timer -- needs mounted screen (set_interval available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restart_timer_runs_after_mount():
+    """_restart_timer sets up a periodic timer without raising."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            # Don't patch _restart_timer so it actually runs
+            app.push_screen(screen)
+            await pilot.pause()
+
+        assert screen._refresh_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_restart_timer_stops_existing_timer():
+    """_restart_timer cancels an existing timer before creating a new one."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        first_timer = screen._refresh_timer
+        screen._restart_timer()
+        await pilot.pause()
+        assert screen._refresh_timer is not first_timer
+
+
+# ---------------------------------------------------------------------------
+# _redraw with y_scale != 1.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redraw_with_y_scale_active():
+    """_redraw executes the y_scale != 1.0 branch without error."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(10)
+        screen._y_scale = 2.0  # triggers y_scale != 1.0 branch
+        screen._redraw()
+        await pilot.pause()
+
+        from textual.widgets import Static
+
+        ohlc = screen.query_one("#ohlc-bar", Static)
+        assert "O:" in str(ohlc.content)
+
+
+# ---------------------------------------------------------------------------
+# _prefetch_history and _prefetch_future full worker paths (with data)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefetch_history_worker_with_data():
+    """_prefetch_history worker calls _prepend_data when fetch succeeds."""
+    from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            for idx, level in enumerate(_ZOOM_LEVELS):
+                if level[2] in _HISTORICAL_INTERVALS:
+                    screen._zoom_idx = idx
+                    break
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        older = _make_candle_data(3)
+        older.dates = [f"2025-02-{i + 1:02d} 09:30" for i in range(3)]
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        with patch("stonks_cli.chart._fetch_candles", return_value=older):
+            with patch.object(screen, cftir, side_effect=record_call):
+                CandleChartScreen._prefetch_history.__wrapped__(screen)
+
+        assert any(fn == screen._prepend_data for fn, _ in calls)
+
+
+@pytest.mark.asyncio
+async def test_prefetch_history_worker_fetch_error():
+    """_prefetch_history worker resets _prefetching on exception."""
+    from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            for idx, level in enumerate(_ZOOM_LEVELS):
+                if level[2] in _HISTORICAL_INTERVALS:
+                    screen._zoom_idx = idx
+                    break
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._prefetching = True
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        err = RuntimeError("error")
+        with patch("stonks_cli.chart._fetch_candles", side_effect=err):
+            with patch.object(screen, cftir, side_effect=record_call):
+                CandleChartScreen._prefetch_history.__wrapped__(screen)
+
+        assert any(fn == setattr for fn, _ in calls)
+
+
+@pytest.mark.asyncio
+async def test_prefetch_future_worker_with_data():
+    """_prefetch_future worker calls _append_data when fetch succeeds."""
+    from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            for idx, level in enumerate(_ZOOM_LEVELS):
+                if level[2] in _HISTORICAL_INTERVALS:
+                    screen._zoom_idx = idx
+                    break
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        newer = _CandleData(
+            dates=["2025-03-20 09:30", "2025-03-21 09:30"],
+            opens=[110.0, 111.0],
+            highs=[115.0, 116.0],
+            lows=[108.0, 109.0],
+            closes=[112.0, 113.0],
+            volumes=[1500.0, 1600.0],
+        )
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        with patch("stonks_cli.chart._fetch_candles", return_value=newer):
+            with patch.object(screen, cftir, side_effect=record_call):
+                CandleChartScreen._prefetch_future.__wrapped__(screen)
+
+        assert any(fn == screen._append_data for fn, _ in calls)
+
+
+@pytest.mark.asyncio
+async def test_prefetch_future_worker_fetch_error():
+    """_prefetch_future worker resets _prefetching on exception."""
+    from stonks_cli.chart import _HISTORICAL_INTERVALS
+
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            for idx, level in enumerate(_ZOOM_LEVELS):
+                if level[2] in _HISTORICAL_INTERVALS:
+                    screen._zoom_idx = idx
+                    break
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._prefetching = True
+
+        calls = []
+
+        def record_call(fn, *args):
+            calls.append((fn, args))
+
+        cftir = "_call_from_thread_if_running"
+        err = RuntimeError("error")
+        with patch("stonks_cli.chart._fetch_candles", side_effect=err):
+            with patch.object(screen, cftir, side_effect=record_call):
+                CandleChartScreen._prefetch_future.__wrapped__(screen)
+
+        assert any(fn == setattr for fn, _ in calls)
+
+
+# ---------------------------------------------------------------------------
+# Cursor actions that reach position boundary (trigger prefetch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_left_reaches_zero_triggers_prefetch():
+    """Moving cursor left to position 0 triggers _maybe_prefetch_history."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 1  # one step from 0
+
+        with (
+            patch.object(screen, "_maybe_prefetch_history") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_left()
+
+        assert screen._cursor == 0
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cursor_right_reaches_last_triggers_prefetch():
+    """Moving cursor right to last position triggers _maybe_prefetch_future."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        screen._data = _make_candle_data(5)
+        screen._cursor = 3  # one step from last (index 4)
+
+        with (
+            patch.object(screen, "_maybe_prefetch_future") as mock_pf,
+            patch.object(screen, "_redraw"),
+        ):
+            screen.action_cursor_right()
+
+        assert screen._cursor == 4
+        mock_pf.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cursor_right_when_empty():
+    """cursor_right on empty data does nothing."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen.action_cursor_right()
+        mock_redraw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cursor_home_when_empty():
+    """cursor_home on empty data does nothing."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen.action_cursor_home()
+        mock_redraw.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cursor_end_when_empty():
+    """cursor_end on empty data does nothing."""
+    app = _make_app_for_chart()
+
+    async with app.run_test() as pilot:
+        screen = CandleChartScreen("AAPL")
+        with (
+            patch.object(CandleChartScreen, "_load_data"),
+            patch.object(CandleChartScreen, "_restart_timer"),
+            patch.object(CandleChartScreen, "_refresh_bid_ask"),
+        ):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        with patch.object(screen, "_redraw") as mock_redraw:
+            screen.action_cursor_end()
+        mock_redraw.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1002,3 +1002,23 @@ class TestFormatShowTable:
         )
         assert "+10.00%" not in table
         assert "--" in table
+
+    def test_watchlist_row_included_in_table(self):
+        """Watchlist items render as rows in the show table (WATCHLIST branch)."""
+        from stonks_cli.models import WatchlistItem
+
+        portfolio = Portfolio(
+            watchlist=[WatchlistItem(symbol="TSLA")],
+            base_currency="USD",
+        )
+        table = format_show_table(
+            portfolio,
+            _mock_snapshot(
+                prices={"TSLA": 250.0},
+                sessions={"TSLA": "regular"},
+                forex_rates={"USD": {"USD": 1.0}},
+                prev_closes={"TSLA": 240.0},
+            ),
+        )
+        assert "TSLA" in table
+        assert "-" in table  # no qty/cost for watchlist

--- a/tests/test_crypto_fetcher.py
+++ b/tests/test_crypto_fetcher.py
@@ -1,0 +1,324 @@
+"""Tests for stonks_cli.crypto_fetcher."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import stonks_cli.crypto_fetcher as cf_module
+from stonks_cli.crypto_fetcher import (
+    CryptoFetcher,
+    _coingecko_error_summary,
+    _crypto_base,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_crypto_base_btc_usd():
+    assert _crypto_base("BTC-USD") == "BTC"
+
+
+def test_crypto_base_lowercase():
+    assert _crypto_base("eth-usd") == "ETH"
+
+
+def test_crypto_base_no_dash():
+    assert _crypto_base("SOL") == "SOL"
+
+
+def test_coingecko_error_summary_rate_limit_401():
+    exc = MagicMock(spec=httpx.HTTPStatusError)
+    exc.response = MagicMock()
+    exc.response.status_code = 401
+    assert "rate limit" in _coingecko_error_summary(exc).lower()
+
+
+def test_coingecko_error_summary_rate_limit_429():
+    exc = MagicMock(spec=httpx.HTTPStatusError)
+    exc.response = MagicMock()
+    exc.response.status_code = 429
+    assert "rate limit" in _coingecko_error_summary(exc).lower()
+
+
+def test_coingecko_error_summary_other_http():
+    exc = MagicMock(spec=httpx.HTTPStatusError)
+    exc.response = MagicMock()
+    exc.response.status_code = 500
+    assert "HTTP 500" in _coingecko_error_summary(exc)
+
+
+def test_coingecko_error_summary_non_http():
+    exc = ValueError("timeout")
+    result = _coingecko_error_summary(exc)
+    assert "ValueError" in result
+
+
+# ---------------------------------------------------------------------------
+# CryptoFetcher.__init__ with API key
+# ---------------------------------------------------------------------------
+
+
+def test_init_with_api_key():
+    with patch.dict("os.environ", {"COINGECKO_DEMO_API_KEY": "testkey"}):
+        fetcher = CryptoFetcher()
+        assert fetcher._http.headers.get("x-cg-demo-api-key") == "testkey"
+
+
+def test_init_without_api_key():
+    with patch.dict("os.environ", {}, clear=True):
+        # Remove the key if present
+        import os
+
+        os.environ.pop("COINGECKO_DEMO_API_KEY", None)
+        fetcher = CryptoFetcher()
+        assert "x-cg-demo-api-key" not in fetcher._http.headers
+
+
+# ---------------------------------------------------------------------------
+# _ensure_coin_list
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_coin_cache():
+    """Reset the module-level cache before each test."""
+    original_cache = cf_module._cg_symbol_to_id.copy()
+    original_loaded = cf_module._cg_coin_list_loaded
+    cf_module._cg_symbol_to_id.clear()
+    cf_module._cg_coin_list_loaded = False
+    yield
+    cf_module._cg_symbol_to_id.clear()
+    cf_module._cg_symbol_to_id.update(original_cache)
+    cf_module._cg_coin_list_loaded = original_loaded
+
+
+def test_ensure_coin_list_loads_mapping():
+    fake_json = json.dumps({"BTC": "bitcoin", "ETH": "ethereum"})
+    mock_resource = MagicMock()
+    mock_resource.read_text.return_value = fake_json
+
+    with patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value = mock_resource
+        CryptoFetcher._ensure_coin_list()
+
+    assert cf_module._cg_symbol_to_id.get("BTC") == "bitcoin"
+    assert cf_module._cg_symbol_to_id.get("ETH") == "ethereum"
+    assert cf_module._cg_coin_list_loaded is True
+
+
+def test_ensure_coin_list_skips_if_already_loaded():
+    cf_module._cg_coin_list_loaded = True
+    cf_module._cg_symbol_to_id["BTC"] = "bitcoin"
+
+    with patch("importlib.resources.files") as mock_files:
+        CryptoFetcher._ensure_coin_list()
+        mock_files.assert_not_called()
+
+
+def test_ensure_coin_list_file_not_found():
+    with patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value.read_text.side_effect = (
+            FileNotFoundError()
+        )
+        CryptoFetcher._ensure_coin_list()  # should not raise
+
+    assert cf_module._cg_coin_list_loaded is False
+
+
+def test_ensure_coin_list_malformed_json():
+    with patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value.read_text.return_value = (
+            "not-json{{{"
+        )
+        CryptoFetcher._ensure_coin_list()  # should not raise
+
+    assert cf_module._cg_coin_list_loaded is False
+
+
+def test_ensure_coin_list_unexpected_exception():
+    with patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value.read_text.side_effect = (
+            RuntimeError("disk error")
+        )
+        CryptoFetcher._ensure_coin_list()  # should not raise
+
+    assert cf_module._cg_coin_list_loaded is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_via_search
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_via_search_success():
+    fetcher = CryptoFetcher()
+    fetcher._http = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {
+        "coins": [
+            {"symbol": "btc", "id": "bitcoin"},
+            {"symbol": "eth", "id": "ethereum"},
+        ]
+    }
+    fetcher._http.get.return_value = resp
+
+    result = fetcher._resolve_via_search("BTC")
+    assert result == "bitcoin"
+
+
+def test_resolve_via_search_no_match():
+    fetcher = CryptoFetcher()
+    fetcher._http = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"coins": [{"symbol": "eth", "id": "ethereum"}]}
+    fetcher._http.get.return_value = resp
+
+    result = fetcher._resolve_via_search("BTC")
+    assert result is None
+
+
+def test_resolve_via_search_http_error():
+    fetcher = CryptoFetcher()
+    fetcher._http = MagicMock()
+    fetcher._http.get.side_effect = httpx.RequestError("timeout")
+
+    result = fetcher._resolve_via_search("BTC")
+    assert result is None
+
+
+def test_resolve_via_search_unexpected_error():
+    fetcher = CryptoFetcher()
+    fetcher._http = MagicMock()
+    fetcher._http.get.side_effect = RuntimeError("unexpected")
+
+    result = fetcher._resolve_via_search("BTC")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_coingecko_batch error paths
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_coingecko_batch_batch_fails_individual_retry():
+    """When batch fails, individual retries are attempted."""
+    fetcher = CryptoFetcher()
+
+    call_count = 0
+
+    def fake_fetch(ids_str: str) -> dict:
+        nonlocal call_count
+        call_count += 1
+        if "," in ids_str:
+            # Batch fails
+            raise httpx.RequestError("network error")
+        # Individual succeeds
+        return {ids_str: {"usd": 50000.0, "usd_24h_change": 2.0}}
+
+    fetcher._fetch_simple_price = fake_fetch
+    result = fetcher._fetch_coingecko_batch(["bitcoin", "ethereum"])
+
+    # batch (1) + 2 individual retries = 3 calls
+    assert call_count == 3
+    assert "bitcoin" in result and "ethereum" in result
+
+
+def test_fetch_coingecko_batch_individual_http_error():
+    """Individual retry failing with HTTP error is logged and skipped."""
+    fetcher = CryptoFetcher()
+
+    def fake_fetch(ids_str: str) -> dict:
+        raise httpx.RequestError("network error")
+
+    fetcher._fetch_simple_price = fake_fetch
+    result = fetcher._fetch_coingecko_batch(["bitcoin"])
+    assert result == {}
+
+
+def test_fetch_coingecko_batch_individual_unexpected_error():
+    """Individual retry failing with unexpected error is caught."""
+    fetcher = CryptoFetcher()
+
+    batch_called = False
+
+    def fake_fetch(ids_str: str) -> dict:
+        nonlocal batch_called
+        if not batch_called:
+            batch_called = True
+            raise httpx.RequestError("batch fail")
+        raise RuntimeError("unexpected individual error")
+
+    fetcher._fetch_simple_price = fake_fetch
+    result = fetcher._fetch_coingecko_batch(["bitcoin"])
+    assert result == {}
+
+
+def test_fetch_coingecko_batch_unexpected_batch_error():
+    """Unexpected exception during batch is caught."""
+    fetcher = CryptoFetcher()
+    fetcher._fetch_simple_price = MagicMock(side_effect=RuntimeError("disk error"))
+    result = fetcher._fetch_coingecko_batch(["bitcoin"])
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_coingecko_response
+# ---------------------------------------------------------------------------
+
+
+def test_parse_coingecko_response_normal():
+    result = {"bitcoin": {"usd": 50000.0, "usd_24h_change": 2.0}}
+    id_to_syms = {"bitcoin": ["BTC-USD"]}
+    prices, prev_closes = CryptoFetcher._parse_coingecko_response(result, id_to_syms)
+    assert prices["BTC-USD"] == 50000.0
+    assert "BTC-USD" in prev_closes
+
+
+def test_parse_coingecko_response_missing_usd_price():
+    """Items with no 'usd' price are skipped."""
+    result = {"bitcoin": {"usd_24h_change": 2.0}}  # no 'usd' key
+    id_to_syms = {"bitcoin": ["BTC-USD"]}
+    prices, prev_closes = CryptoFetcher._parse_coingecko_response(result, id_to_syms)
+    assert "BTC-USD" not in prices
+
+
+def test_parse_coingecko_response_none_usd_price():
+    """Items with usd=None are skipped."""
+    result = {"bitcoin": {"usd": None, "usd_24h_change": 2.0}}
+    id_to_syms = {"bitcoin": ["BTC-USD"]}
+    prices, prev_closes = CryptoFetcher._parse_coingecko_response(result, id_to_syms)
+    assert "BTC-USD" not in prices
+
+
+def test_parse_coingecko_response_no_change():
+    """Items with no change still produce a price."""
+    result = {"bitcoin": {"usd": 50000.0}}
+    id_to_syms = {"bitcoin": ["BTC-USD"]}
+    prices, prev_closes = CryptoFetcher._parse_coingecko_response(result, id_to_syms)
+    assert prices["BTC-USD"] == 50000.0
+    assert "BTC-USD" not in prev_closes
+
+
+def test_parse_coingecko_response_value_error():
+    """ValueError from non-numeric price is caught and logged."""
+    # float("not-a-number") raises ValueError
+    result = {"bitcoin": {"usd": "not-a-number", "usd_24h_change": 2.0}}
+    id_to_syms = {"bitcoin": ["BTC-USD"]}
+    prices, prev_closes = CryptoFetcher._parse_coingecko_response(result, id_to_syms)
+    assert "BTC-USD" not in prices
+
+
+# ---------------------------------------------------------------------------
+# fetch_prices_and_changes integration
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_prices_empty_symbols():
+    fetcher = CryptoFetcher()
+    prices, prev = fetcher.fetch_prices_and_changes([])
+    assert prices == {}
+    assert prev == {}

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,580 @@
+"""Tests for form dialog screens in stonks_cli.forms."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from textual.widgets import Checkbox, Input, Label
+
+from stonks_cli.app import PortfolioApp
+from stonks_cli.dto import BacktestConfig
+from stonks_cli.forms import (
+    _BacktestFormScreen,
+    _CashFormScreen,
+    _ConfirmScreen,
+    _TypeSelectScreen,
+    _validate_positive_float,
+    _validate_required,
+)
+from stonks_cli.models import Portfolio, Position
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+USD_RATES = {"USD": {"USD": 1.0}}
+
+
+def _make_app() -> PortfolioApp:
+    portfolio = Portfolio(
+        positions=[Position(symbol="AAPL", quantity=10, avg_cost=150.0)]
+    )
+    return PortfolioApp(
+        portfolios=[portfolio],
+        prices={"AAPL": 160.0},
+        forex_rates=USD_RATES,
+    )
+
+
+def _make_fake_button_event(button_id: str) -> MagicMock:
+    """Create a fake Button.Pressed event with the given button id."""
+    event = MagicMock()
+    event.button = MagicMock()
+    event.button.id = button_id
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRequired:
+    def test_empty_string_updates_error_and_returns_false(self):
+        err = MagicMock()
+        result = _validate_required("", "Symbol", err)
+        assert result is False
+        err.update.assert_called_once_with("Symbol is required")
+
+    def test_non_empty_returns_true(self):
+        err = MagicMock()
+        result = _validate_required("AAPL", "Symbol", err)
+        assert result is True
+        err.update.assert_not_called()
+
+
+class TestValidatePositiveFloat:
+    def test_valid_positive_number(self):
+        err = MagicMock()
+        result = _validate_positive_float("10.5", "Quantity", err)
+        assert result == 10.5
+        err.update.assert_not_called()
+
+    def test_zero_updates_error(self):
+        err = MagicMock()
+        result = _validate_positive_float("0", "Quantity", err)
+        assert result is None
+        err.update.assert_called_once()
+
+    def test_negative_updates_error(self):
+        err = MagicMock()
+        result = _validate_positive_float("-5.0", "Quantity", err)
+        assert result is None
+        err.update.assert_called_once()
+
+    def test_non_numeric_updates_error(self):
+        err = MagicMock()
+        result = _validate_positive_float("abc", "Quantity", err)
+        assert result is None
+        err.update.assert_called_once_with("Quantity must be a positive number")
+
+    def test_integer_string_valid(self):
+        err = MagicMock()
+        result = _validate_positive_float("100", "Amount", err)
+        assert result == 100.0
+
+
+# ---------------------------------------------------------------------------
+# _BacktestFormScreen compose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_compose():
+    """_BacktestFormScreen creates all expected input fields."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen.query_one("#benchmark", Input).value == "SPY"
+        assert screen.query_one("#start_amount", Input).value == "10000"
+        assert screen.query_one("#start_year", Input).value == "2010"
+        assert screen.query_one("#cashflows", Input).value == "0"
+        assert screen.query_one("#skip_unavailable", Checkbox).value is True
+
+        end_year = screen.query_one("#end_year", Input).value
+        assert end_year != ""
+        assert len(end_year) == 4 and end_year.isdigit()
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_custom_initial_values():
+    """_BacktestFormScreen accepts custom initial values."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(
+            benchmark="QQQ",
+            start_amount="50000",
+            start_year="2015",
+            end_year="2023",
+            cashflows="5000",
+        )
+        app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen.query_one("#benchmark", Input).value == "QQQ"
+        assert screen.query_one("#start_amount", Input).value == "50000"
+        assert screen.query_one("#start_year", Input).value == "2015"
+        assert screen.query_one("#end_year", Input).value == "2023"
+        assert screen.query_one("#cashflows", Input).value == "5000"
+
+
+# ---------------------------------------------------------------------------
+# _BacktestFormScreen cancel / escape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_cancel_dismisses_with_none():
+    """Cancel button (via on_button_pressed) dismisses with None."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        # Trigger cancel via on_button_pressed directly
+        screen.on_button_pressed(_make_fake_button_event("cancel"))
+        await pilot.pause()
+
+        assert dismissed_values == [None]
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_escape_dismisses_with_none():
+    """Pressing Escape dismisses with None (on_key handler)."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert dismissed_values == [None]
+
+
+# ---------------------------------------------------------------------------
+# _BacktestFormScreen submit - valid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_submit_valid_data():
+    """Submitting valid data via _submit() produces a BacktestConfig."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="2015", end_year="2023")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen._submit()
+        await pilot.pause()
+
+        assert len(dismissed_values) == 1
+        config = dismissed_values[0]
+        assert isinstance(config, dict)
+        assert config["benchmark"] == "SPY"
+        assert config["start_amount"] == 10000.0
+        assert config["start_year"] == 2015
+        assert config["end_year"] == 2023
+        assert config["cashflows"] == 0.0
+        assert config["rebalance"] == "none"
+        assert isinstance(config["skip_unavailable"], bool)
+
+
+# ---------------------------------------------------------------------------
+# _BacktestFormScreen submit - validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_empty_benchmark_shows_error():
+    """Empty benchmark field shows an error without dismissing."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen.query_one("#benchmark", Input).value = ""
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert str(err.content) != ""
+        assert dismissed_values == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_invalid_start_amount_shows_error():
+    """Non-numeric start amount shows an error without dismissing."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen.query_one("#start_amount", Input).value = "notanumber"
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert str(err.content) != ""
+        assert dismissed_values == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_invalid_year_range_shows_error():
+    """Start year after end year shows a year error."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="2025", end_year="2015")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert "year" in str(err.content).lower()
+        assert dismissed_values == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_negative_cashflows_shows_error():
+    """Negative cashflows show an error."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="2015", end_year="2023")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen.query_one("#cashflows", Input).value = "-100"
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert "cashflow" in str(err.content).lower()
+        assert dismissed_values == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_year_before_1970_shows_error():
+    """Start year before 1970 shows a year error."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="1960", end_year="2023")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert "year" in str(err.content).lower()
+        assert dismissed_values == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_non_numeric_year_shows_error():
+    """Non-numeric start year shows a year error."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="abc", end_year="2023")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen._submit()
+        await pilot.pause()
+
+        err = screen.query_one("#error", Label)
+        assert "year" in str(err.content).lower()
+        assert dismissed_values == []
+
+
+# ---------------------------------------------------------------------------
+# _BacktestFormScreen -- enter key on focused Input triggers submit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backtest_form_enter_on_input_triggers_submit():
+    """Pressing Enter while an Input is focused calls _submit."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _BacktestFormScreen(start_year="2015", end_year="2023")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        # Focus the benchmark input and press enter
+        await pilot.click("#benchmark")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # Valid form should be dismissed
+        assert len(dismissed_values) == 1
+
+
+# ---------------------------------------------------------------------------
+# _TypeSelectScreen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_type_select_equity_dismisses_with_equity():
+    """Clicking equity dismisses with 'equity'."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _TypeSelectScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.click("#equity")
+        await pilot.pause()
+
+        assert dismissed_values == ["equity"]
+
+
+@pytest.mark.asyncio
+async def test_type_select_cash_dismisses_with_cash():
+    """Clicking cash dismisses with 'cash'."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _TypeSelectScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.click("#cash")
+        await pilot.pause()
+
+        assert dismissed_values == ["cash"]
+
+
+@pytest.mark.asyncio
+async def test_type_select_cancel_dismisses_with_none():
+    """Clicking cancel dismisses with None."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _TypeSelectScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.click("#cancel")
+        await pilot.pause()
+
+        assert dismissed_values == [None]
+
+
+@pytest.mark.asyncio
+async def test_type_select_escape_dismisses_with_none():
+    """Pressing escape dismisses with None."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _TypeSelectScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert dismissed_values == [None]
+
+
+@pytest.mark.asyncio
+async def test_type_select_portfolio_name_shown():
+    """Portfolio name is shown in the dialog when provided."""
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = _TypeSelectScreen(portfolio_name="My Fund")
+        app.push_screen(screen)
+        await pilot.pause()
+
+        labels = screen.query(Label)
+        texts = [str(lb.content) for lb in labels]
+        assert any("My Fund" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# _ConfirmScreen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_confirm_screen_yes_dismisses_true():
+    """Clicking Remove dismisses with True."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _ConfirmScreen("Delete this position?")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.click("#yes")
+        await pilot.pause()
+
+        assert dismissed_values == [True]
+
+
+@pytest.mark.asyncio
+async def test_confirm_screen_no_dismisses_false():
+    """Clicking Cancel dismisses with False."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _ConfirmScreen("Delete this position?")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.click("#no")
+        await pilot.pause()
+
+        assert dismissed_values == [False]
+
+
+@pytest.mark.asyncio
+async def test_confirm_screen_escape_dismisses_false():
+    """Pressing escape dismisses with False."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _ConfirmScreen("Are you sure?")
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert dismissed_values == [False]
+
+
+# ---------------------------------------------------------------------------
+# _CashFormScreen -- enter key on input triggers submit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cash_form_enter_on_input_triggers_submit():
+    """Pressing Enter while an Input is focused triggers _submit."""
+    app = _make_app()
+    dismissed_values: list = []
+
+    async with app.run_test() as pilot:
+        screen = _CashFormScreen()
+        app.push_screen(screen, callback=dismissed_values.append)
+        await pilot.pause()
+
+        screen.query_one("#currency", Input).value = "EUR"
+        screen.query_one("#amount", Input).value = "1000"
+
+        # Focus the currency input and press Enter
+        await pilot.click("#currency")
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert len(dismissed_values) == 1
+        assert dismissed_values[0]["currency"] == "EUR"
+        assert dismissed_values[0]["amount"] == 1000.0
+
+
+# ---------------------------------------------------------------------------
+# ScrollableScreenMixin via BacktestScreen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scrollable_mixin_actions():
+    """ScrollableScreenMixin scroll action methods delegate to VerticalScroll."""
+    from stonks_cli.backtest_detail import BacktestScreen
+    from stonks_cli.models import Portfolio, Position
+
+    portfolio = Portfolio(positions=[Position("AAPL", 10, 150.0)])
+    config: BacktestConfig = {
+        "benchmark": "SPY",
+        "start_amount": 10000,
+        "start_year": 2020,
+        "end_year": 2022,
+        "cashflows": 0,
+        "rebalance": "none",
+        "skip_unavailable": False,
+    }
+    app = _make_app()
+
+    async with app.run_test() as pilot:
+        screen = BacktestScreen(portfolio, config)
+        with patch.object(BacktestScreen, "_run_backtest"):
+            app.push_screen(screen)
+            await pilot.pause()
+
+        scroll_widget = screen.query_one("#bt-scroll")
+        scroll_widget.scroll_up = MagicMock()
+        scroll_widget.scroll_down = MagicMock()
+        scroll_widget.scroll_page_up = MagicMock()
+        scroll_widget.scroll_page_down = MagicMock()
+
+        screen.action_scroll_up()
+        screen.action_scroll_down()
+        screen.action_page_up()
+        screen.action_page_down()
+
+        scroll_widget.scroll_up.assert_called_once()
+        scroll_widget.scroll_down.assert_called_once()
+        scroll_widget.scroll_page_up.assert_called_once()
+        scroll_widget.scroll_page_down.assert_called_once()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -197,3 +197,26 @@ def test_thread_guard_unknown_runtime_error_reraises():
     guard = _ConcreteGuard(side_effect=RuntimeError("something unexpected"))
     with pytest.raises(RuntimeError, match="something unexpected"):
         guard._call_from_thread_if_running(lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# stonks_cli.__version__ fallback
+# ---------------------------------------------------------------------------
+
+
+def test_version_fallback_when_package_not_installed():
+    """__version__ falls back to '0.0.0.dev' when PackageNotFoundError is raised."""
+    import importlib
+    import importlib.metadata
+    import unittest.mock
+    from importlib.metadata import PackageNotFoundError
+
+    import stonks_cli
+
+    with unittest.mock.patch(
+        "importlib.metadata.version", side_effect=PackageNotFoundError
+    ):
+        importlib.reload(stonks_cli)
+        assert stonks_cli.__version__ == "0.0.0.dev"
+    # Restore to real version
+    importlib.reload(stonks_cli)


### PR DESCRIPTION
- `test_backtest.py` - Edge cases: single-symbol == benchmark, zero initial price for portfolio and benchmark, _closest_date_index boundaries.
- `test_chart.py` - ~57 new tests: _CandleData merge methods, _draw_candles, TUI compose/redraw/resize/cursor, worker threads, prefetch history/future (data, errors, boundary triggers).
- `test_cli.py` - WATCHLIST branch in format_show_table: WatchlistItem rows render with placeholder dashes.
- `test_helpers.py` - PackageNotFoundError fallback in stonks_cli/__init__.py sets __version__ = "0.0.0.dev".
- `test_backtest_detail.py` (new, 20 tests) - BacktestScreen compose, title/subtitle, error display, result rendering (full/empty/skipped), summary stats, _downsample, worker threads, scroll bindings.
- `test_crypto_fetcher.py` (new, 28 tests) - CryptoFetcher init, coin list loading, symbol resolution, batch fetching with retry, response parsing, error paths throughout.
- `test_forms.py` (new, 29 tests) ` Validation helpers, _BacktestFormScreen (all validation paths, submit, cancel/escape), _TypeSelectScreen, _ConfirmScreen, _CashFormScreen, ScrollableScreenMixin.