### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-12
+
+### Added
+
+- Portfolio backtesting: press `b` on any portfolio to simulate its historical
+  growth against a benchmark (default: SPY), with configurable start year,
+  initial amount, annual cashflows, and rebalancing strategy. Backtest
+  results screen shows CAGR, Sharpe ratio, max drawdown, best/worst
+  year, and an annual returns chart for both the portfolio and benchmark.
+
+### Changed
+
+- Build tooling migrated from Poetry to `uv`; a `Makefile` now provides
+  unified targets (`make check`, `make test`, `make format`) used by CI,
+  pre-commit hooks, and local development alike.
+- Internal refactoring
+- Public API cleanup: leading underscores removed from cross-module types and
+  screen classes (`RowMeta`, `TuiRowData`, `to_tui_rows`, `ROW_KIND_LABELS`,
+  form screen classes).
+
 ## [0.5.0] - 2026-04-05
 
 ### Added
@@ -303,6 +323,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `show` command to `dashboard`
 
+[0.6.0]: https://github.com/igoropaniuk/stonks-cli/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/igoropaniuk/stonks-cli/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/igoropaniuk/stonks-cli/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/igoropaniuk/stonks-cli/compare/v0.4.0...v0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stonks-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "CLI tool for tracking investment portfolio"
 authors = [{ name = "Igor Opaniuk", email = "igor.opaniuk@gmail.com" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -1394,7 +1394,7 @@ wheels = [
 
 [[package]]
 name = "stonks-cli"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Update pyproject.toml to 0.6.0 and add a changelog entry for changes since v0.5.0.

Document the new backtesting feature (b key, configurable parameters, results screen with CAGR/Sharpe/drawdown), the run_backtest() decomposition, public API cleanup (dropped underscore prefixes from cross-module types and screen classes), and smaller refactors (to_tui_rows split, _redraw split, unified _handle_add).