### PR TITLE
docs(readme): add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,26 @@ stonks demo # create demo portfolio
 
 **Requirements:** Python 3.11+
 
+### [Homebrew](https://brew.sh/) (macOS / Linux)
+
+```bash
+brew tap igoropaniuk/tap
+brew install stonks-cli
+```
+
+### [pip](https://pip.pypa.io/)
+
 ```bash
 pip install stonks-cli
 ```
 
-Or with [pipx](https://pipx.pypa.io/) (recommended -- keeps the tool isolated):
+### [pipx](https://pipx.pypa.io/) (recommended -- keeps the tool isolated)
 
 ```bash
 pipx install stonks-cli
 ```
 
-Or with [uv](https://docs.astral.sh/uv/):
+### [uv](https://docs.astral.sh/uv/)
 
 ```bash
 uv tool install stonks-cli


### PR DESCRIPTION
Add brew tap / brew install as an installation method now that the igoropaniuk/homebrew-tap formula is available. Keep pip, pipx, and uv as alternatives. Update the quick-start snippet and the install badge.