### PR TITLE
chore(release): bump version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-04-15
+
+### Fixed
+
+- `stonks doctor` no longer fails on clean installs: replaced the
+  `packaging.version` import (not a declared dependency) with an inline
+  tuple-based version comparison.
+
 ## [0.6.1] - 2026-04-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stonks-cli"
-version = "0.6.1"
+version = "0.6.2"
 description = "CLI tool for tracking investment portfolio"
 authors = [{ name = "Igor Opaniuk", email = "igor.opaniuk@gmail.com" }]
 requires-python = ">=3.11,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -1394,7 +1394,7 @@ wheels = [
 
 [[package]]
 name = "stonks-cli"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fix stonks doctor failing on clean installs by replacing the packaging.version import (not a declared dependency) with an inline tuple-based version comparison.