### PR TITLE
fix(detail): filter NaN/inf from price history before plotting

### DIFF
--- a/src/stonks_cli/stock_detail.py
+++ b/src/stonks_cli/stock_detail.py
@@ -211,9 +211,13 @@ class StockDetailFetcher:
                 h = t.history(**kw)
                 if h is not None and not h.empty:
                     fmt = "%H:%M" if interval else "%Y-%m-%d"
-                    dates = [d.strftime(fmt) for d in h.index]
-                    closes = [float(v) for v in h["Close"].tolist()]
-                    result[label] = (dates, closes)
+                    # Filter out NaN/inf values that would crash plotext
+                    h_finite = h[h["Close"].apply(_finite).notna()]
+                    if not h_finite.empty:
+                        result[label] = (
+                            h_finite.index.strftime(fmt).tolist(),
+                            h_finite["Close"].astype(float).tolist(),
+                        )
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "Cannot fetch price history for %s (%s): %s", symbol, period, exc


### PR DESCRIPTION
yfinance may return NaN or non-finite values in the Close column for certain tickers (e.g. QCOM). These values pass through float() without error but crash plotext during rendering when it internally converts them to the string 'N/A' and then fails to parse that back as a float.

Use the existing _finite() helper to drop non-finite entries (and their corresponding dates) before handing data to PlotextPlot.