### PR TITLE
fix(exchanges): narrow extended-hours window to real pre/post-market bounds

### DIFF
--- a/src/stonks_cli/exchanges.py
+++ b/src/stonks_cli/exchanges.py
@@ -235,6 +235,14 @@ _US_EXCHANGE = ExchangeInfo(
     extended_hours=True,
 )
 
+# Extended-hours bounds in each exchange's local time.  Only applied when
+# ExchangeInfo.extended_hours is True; all such entries today are NYSE /
+# NASDAQ (US) with the same 04:00 / 20:00 ET window.  If a non-US exchange
+# ever enables extended hours with different bounds, push these down onto
+# ExchangeInfo.
+_EXTENDED_PRE_OPEN = dtime(4, 0)
+_EXTENDED_POST_CLOSE = dtime(20, 0)
+
 
 # Reverse lookup: yfinance exchange code -> display label, derived from _EXCHANGES.
 _YF_CODE_TO_LABEL: dict[str, str] = {
@@ -415,8 +423,18 @@ class ExchangeSession:
             return Session.CLOSED
         now = pd.Timestamp.now(tz="UTC")
         session = ExchangeSession.market_session(now, *hours)
-        if session != Session.REGULAR and not ExchangeSession.extended_hours_for(
-            symbol
-        ):
+        if session == Session.REGULAR:
+            return session
+        if not ExchangeSession.extended_hours_for(symbol):
+            return Session.CLOSED
+        # ``market_session`` reports PRE for *any* time before the regular
+        # open and POST for *any* time after the regular close, so the dead
+        # of night gets labelled pre-market.  Narrow those windows to the
+        # real extended-hours bounds so 02:00 ET isn't treated as NYSE
+        # pre-market (which actually starts at 04:00 ET).
+        local_time = now.astimezone(zoneinfo.ZoneInfo(hours[0])).time()
+        if session == Session.PRE and local_time < _EXTENDED_PRE_OPEN:
+            return Session.CLOSED
+        if session == Session.POST and local_time >= _EXTENDED_POST_CLOSE:
             return Session.CLOSED
         return session

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -829,19 +829,64 @@ class TestCurrentSession:
     def test_non_trading_day_returns_closed(self, _td, fetcher: PriceFetcher):
         assert fetcher.current_session("AAPL") == "closed"
 
+    # 05:00 ET = 09:00 UTC on a standard-time date -- inside NYSE pre-market
+    # (04:00-09:30 ET), so current_session should honour the "pre" label from
+    # market_session rather than narrowing it to "closed".
+    _US_PRE_UTC = pd.Timestamp("2026-03-10 09:00:00", tz="UTC")
+    # 03:00 ET = 07:00 UTC on the same date -- before real pre-market starts.
+    _US_BEFORE_PRE_UTC = pd.Timestamp("2026-03-10 07:00:00", tz="UTC")
+    # 17:00 ET = 21:00 UTC -- inside NYSE post-market (16:00-20:00 ET).
+    _US_POST_UTC = pd.Timestamp("2026-03-10 21:00:00", tz="UTC")
+    # 22:00 ET = 02:00 UTC next day -- after post-market has closed.
+    _US_AFTER_POST_UTC = pd.Timestamp("2026-03-11 02:00:00", tz="UTC")
+
     @patch(_TRADING_DAY, return_value=True)
     @patch("stonks_cli.fetcher.ExchangeSession.market_session", return_value="pre")
+    @patch("stonks_cli.fetcher.pd.Timestamp.now")
     def test_trading_day_delegates_to_market_session(
-        self, mock_ms, _td, fetcher: PriceFetcher
+        self, mock_now, mock_ms, _td, fetcher: PriceFetcher
     ):
+        mock_now.return_value = self._US_PRE_UTC
         result = fetcher.current_session("AAPL")
         assert result == "pre"
         assert mock_ms.called
 
     @patch(_TRADING_DAY, return_value=True)
     @patch("stonks_cli.fetcher.ExchangeSession.market_session", return_value="pre")
+    @patch("stonks_cli.fetcher.pd.Timestamp.now")
+    def test_us_before_pre_market_window_returns_closed(
+        self, mock_now, _ms, _td, fetcher: PriceFetcher
+    ):
+        # 03:00 ET is before real pre-market (04:00 ET) even though
+        # market_session still reports "pre" (any time before regular open).
+        mock_now.return_value = self._US_BEFORE_PRE_UTC
+        assert fetcher.current_session("AAPL") == "closed"
+
+    @patch(_TRADING_DAY, return_value=True)
+    @patch("stonks_cli.fetcher.ExchangeSession.market_session", return_value="post")
+    @patch("stonks_cli.fetcher.pd.Timestamp.now")
+    def test_us_inside_post_market_window_returns_post(
+        self, mock_now, _ms, _td, fetcher: PriceFetcher
+    ):
+        mock_now.return_value = self._US_POST_UTC
+        assert fetcher.current_session("AAPL") == "post"
+
+    @patch(_TRADING_DAY, return_value=True)
+    @patch("stonks_cli.fetcher.ExchangeSession.market_session", return_value="post")
+    @patch("stonks_cli.fetcher.pd.Timestamp.now")
+    def test_us_after_post_market_window_returns_closed(
+        self, mock_now, _ms, _td, fetcher: PriceFetcher
+    ):
+        # 22:00 ET is past post-market close (20:00 ET); market_session still
+        # says "post" because it only knows the regular close.
+        mock_now.return_value = self._US_AFTER_POST_UTC
+        assert fetcher.current_session("AAPL") == "closed"
+
+    @patch(_TRADING_DAY, return_value=True)
+    @patch("stonks_cli.fetcher.ExchangeSession.market_session", return_value="pre")
     def test_non_us_pre_returns_closed(self, _ms, _td, fetcher: PriceFetcher):
         # Non-US exchanges have no extended hours; "pre" should map to "closed"
+        # regardless of local time.
         assert fetcher.current_session("6758.T") == "closed"
 
     @patch(_TRADING_DAY, return_value=True)


### PR DESCRIPTION
## Summary
- `ExchangeSession.market_session` labels *any* time before the regular open as PRE and *any* time after the regular close as POST, so 02:00 ET on a NYSE trading day was being reported as pre-market. The STALE detector then flipped every US row to STALE because the session wasn't CLOSED and the last bar was from a prior trading day.
- `current_session` now narrows the PRE/POST windows to the real extended-hours bounds (04:00 / 20:00 ET for exchanges declaring `extended_hours=True`), so outside those windows it returns CLOSED. The STALE override passes CLOSED through untouched, and the UI correctly shows `CLS` instead of `STALE`.

## Reproducer (before the fix)
```
02:47 ET on a trading day, US portfolio rows
Last Price     Badge
186.88         STALE     <-- wrong, NYSE is closed
210.00         STALE
...
```

## After the fix
```
02:47 ET on a trading day
Last Price     Badge
186.88         CLS       <-- correct
210.00         CLS
```