### PR TITLE
fix(app): suppress browser stdio when opening news links

### DIFF
--- a/src/stonks_cli/app.py
+++ b/src/stonks_cli/app.py
@@ -1,7 +1,11 @@
 """Textual TUI for portfolio display."""
 
 import logging
+import os
+import subprocess
+import sys
 import threading
+import webbrowser
 from collections import deque
 from collections.abc import Callable
 from functools import partial
@@ -875,6 +879,47 @@ class PortfolioApp(ThreadGuardMixin, App[None]):
 
     def on_news_feed_widget_open_url(self, message: NewsFeedWidget.OpenURL) -> None:
         self.open_url(message.url)
+
+    def open_url(self, url: str, *, new_tab: bool = True) -> None:
+        """Open *url* in the system browser, suppressing its stdio.
+
+        Textual's default ``open_url`` delegates to ``webbrowser.open``,
+        which ``Popen``s the browser without redirecting its stdout /
+        stderr.  Anything the browser logs (GL / GPU warnings, D-Bus
+        complaints, etc.) then leaks into the controlling terminal and
+        scribbles over the TUI.  We launch the OS URL handler ourselves
+        with stdio piped to ``DEVNULL`` and ``start_new_session=True``
+        so the child is detached cleanly, and fall back to
+        ``webbrowser.open`` if no system handler is available.
+        """
+        if sys.platform == "darwin":
+            launcher: list[str] | None = ["open", url]
+        elif sys.platform.startswith("win"):
+            launcher = None  # use os.startfile on Windows
+        else:
+            launcher = ["xdg-open", url]
+
+        if launcher is None:
+            try:
+                os.startfile(url)  # type: ignore[attr-defined]
+                return
+            except OSError:
+                webbrowser.open(url, new=2 if new_tab else 0)
+                return
+
+        try:
+            subprocess.Popen(  # noqa: S603 -- argv comes from a fixed list
+                launcher,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except (OSError, FileNotFoundError):
+            # No xdg-open / open on PATH -- fall back to webbrowser, which
+            # still leaks stdio but at least gets the user to the URL.
+            webbrowser.open(url, new=2 if new_tab else 0)
 
     # ------------------------------------------------------------------
     # Rendering helpers

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2605,3 +2605,50 @@ async def test_history_updated_message_syncs_to_app(portfolio: Portfolio) -> Non
         ]
         app.on_history_updated(HistoryUpdated(new_history))
         assert app._chat_history == new_history
+
+
+class TestOpenUrlSuppressesBrowserStdio:
+    """``PortfolioApp.open_url`` must mute the child browser's stdio so that
+    GL / GPU / D-Bus warnings logged by the browser don't bleed into the
+    controlling terminal and corrupt the TUI render.
+    """
+
+    @patch("stonks_cli.app.sys")
+    @patch("stonks_cli.app.subprocess.Popen")
+    def test_linux_launches_xdg_open_with_devnull(self, mock_popen, mock_sys):
+        mock_sys.platform = "linux"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com/article")
+
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        assert args[0] == ["xdg-open", "https://example.com/article"]
+        # The whole point of the override: stdio must be silenced.
+        import subprocess as _sp
+
+        assert kwargs["stdin"] == _sp.DEVNULL
+        assert kwargs["stdout"] == _sp.DEVNULL
+        assert kwargs["stderr"] == _sp.DEVNULL
+        assert kwargs["start_new_session"] is True
+
+    @patch("stonks_cli.app.sys")
+    @patch("stonks_cli.app.subprocess.Popen")
+    def test_macos_launches_open_with_devnull(self, mock_popen, mock_sys):
+        mock_sys.platform = "darwin"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com")
+
+        args, _ = mock_popen.call_args
+        assert args[0] == ["open", "https://example.com"]
+
+    @patch("stonks_cli.app.webbrowser.open")
+    @patch("stonks_cli.app.subprocess.Popen", side_effect=FileNotFoundError)
+    @patch("stonks_cli.app.sys")
+    def test_falls_back_to_webbrowser_when_xdg_open_missing(
+        self, mock_sys, _mock_popen, mock_wb
+    ):
+        mock_sys.platform = "linux"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com", new_tab=True)
+
+        mock_wb.assert_called_once_with("https://example.com", new=2)


### PR DESCRIPTION
## Summary
- Clicking a news headline launched the system browser via Textual's ``open_url`` → ``webbrowser.open``, which ``Popen``s the child without redirecting its stdout/stderr. Any GL / GPU / D-Bus warnings the browser logged then bled onto the controlling terminal and scrambled the TUI.
- Overrides ``PortfolioApp.open_url`` to invoke ``xdg-open`` (Linux) / ``open`` (macOS) / ``os.startfile`` (Windows) directly with ``stdin``, ``stdout``, ``stderr`` piped to ``DEVNULL`` and ``start_new_session=True``, falling back to ``webbrowser.open`` only if no OS launcher is on PATH.

## Reproducer (before the fix)
On a Qualcomm X1 Elite (Adreno X1-85) laptop, clicking a news headline produced terminal output like:
```
[GFX1-]: Couldn't sanitize GL_RENDERER "Adreno X1-85"
0:2(12): error: extension ``GL_EXT_shader_texture_lod`` unsupported in fragment shader
#extension GL_EXT_shader_texture_lod: require
```
…overwriting parts of the rendered portfolio table.

## Test plan
- [x] ``uv run pytest tests/test_app.py::TestOpenUrlSuppressesBrowserStdio`` — 3 new tests cover Linux (xdg-open with DEVNULL), macOS (open), and the fallback when no OS launcher is on PATH.
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy`` all clean.
- [x] Full ``make check-all`` minus the pre-existing time-decayed chart tests (fixed separately on ``test/chart_zoom_relative_dates``): 849 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)