### PR TITLE
fix(app): suppress browser stdio when opening news links

### DIFF
--- a/src/stonks_cli/app.py
+++ b/src/stonks_cli/app.py
@@ -1,7 +1,11 @@
 """Textual TUI for portfolio display."""
 
 import logging
+import os
+import subprocess
+import sys
 import threading
+import webbrowser
 from collections import deque
 from collections.abc import Callable
 from functools import partial
@@ -875,6 +879,72 @@ class PortfolioApp(ThreadGuardMixin, App[None]):
 
     def on_news_feed_widget_open_url(self, message: NewsFeedWidget.OpenURL) -> None:
         self.open_url(message.url)
+
+    def open_url(self, url: str, *, new_tab: bool = True) -> None:
+        """Open *url* in the system browser, suppressing its stdio.
+
+        Textual's default ``open_url`` delegates to ``webbrowser.open``,
+        which ``Popen``s the browser without redirecting its stdout /
+        stderr.  Anything the browser logs (GL / GPU warnings, D-Bus
+        complaints, etc.) then leaks into the controlling terminal and
+        scribbles over the TUI.  We launch the OS URL handler ourselves
+        with stdio piped to ``DEVNULL`` and ``start_new_session=True``
+        so the child is detached cleanly, and fall back to
+        ``webbrowser.open`` if no system handler is available.
+
+        Note: the ``new_tab`` argument is only honoured on the
+        ``webbrowser.open`` fallback path -- ``xdg-open`` / ``open`` /
+        ``os.startfile`` don't expose a portable way to control whether
+        the URL replaces the active tab or spawns a new one.  In
+        practice every modern desktop browser opens external invocations
+        in a new tab anyway, so the parameter is kept for API symmetry
+        with Textual's signature.
+        """
+        if sys.platform == "darwin":
+            launcher: list[str] | None = ["open", url]
+        elif sys.platform.startswith("win"):
+            launcher = None  # use os.startfile on Windows
+        else:
+            launcher = ["xdg-open", url]
+
+        if launcher is None:
+            try:
+                os.startfile(url)  # type: ignore[attr-defined]
+                return
+            except OSError:
+                webbrowser.open(url, new=2 if new_tab else 0)
+                return
+
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv comes from a fixed list
+                launcher,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except OSError:
+            # No xdg-open / open on PATH -- fall back to webbrowser, which
+            # still leaks stdio but at least gets the user to the URL.
+            webbrowser.open(url, new=2 if new_tab else 0)
+            return
+
+        # ``xdg-open`` / ``open`` typically exit within milliseconds after
+        # handing off to the browser, but we never call ``wait()`` from
+        # the foreground, so the kernel would keep the exited child as a
+        # zombie until ``PortfolioApp`` itself exits.  A long-running TUI
+        # that opens many news links would accumulate one entry per click
+        # in the process table.  Run the reap as a Textual worker so the
+        # framework owns its lifecycle (visible in devtools, cleaned up
+        # on app teardown) and we still don't block the UI.
+        self.run_worker(
+            proc.wait,
+            name="open-url-reap",
+            group="open-url",
+            thread=True,
+            exit_on_error=False,
+        )
 
     # ------------------------------------------------------------------
     # Rendering helpers

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2605,3 +2605,99 @@ async def test_history_updated_message_syncs_to_app(portfolio: Portfolio) -> Non
         ]
         app.on_history_updated(HistoryUpdated(new_history))
         assert app._chat_history == new_history
+
+
+class TestOpenUrlSuppressesBrowserStdio:
+    """``PortfolioApp.open_url`` must mute the child browser's stdio so that
+    GL / GPU / D-Bus warnings logged by the browser don't bleed into the
+    controlling terminal and corrupt the TUI render.
+    """
+
+    @patch.object(PortfolioApp, "run_worker")
+    @patch("stonks_cli.app.sys")
+    @patch("stonks_cli.app.subprocess.Popen")
+    def test_linux_launches_xdg_open_with_devnull(
+        self, mock_popen, mock_sys, _mock_worker
+    ):
+        mock_sys.platform = "linux"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com/article")
+
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        assert args[0] == ["xdg-open", "https://example.com/article"]
+        # The whole point of the override: stdio must be silenced.
+        import subprocess as _sp
+
+        assert kwargs["stdin"] == _sp.DEVNULL
+        assert kwargs["stdout"] == _sp.DEVNULL
+        assert kwargs["stderr"] == _sp.DEVNULL
+        assert kwargs["start_new_session"] is True
+
+    @patch.object(PortfolioApp, "run_worker")
+    @patch("stonks_cli.app.sys")
+    @patch("stonks_cli.app.subprocess.Popen")
+    def test_macos_launches_open_with_devnull(self, mock_popen, mock_sys, _mock_worker):
+        mock_sys.platform = "darwin"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com")
+
+        args, _ = mock_popen.call_args
+        assert args[0] == ["open", "https://example.com"]
+
+    @patch("stonks_cli.app.webbrowser.open")
+    @patch("stonks_cli.app.subprocess.Popen", side_effect=FileNotFoundError)
+    @patch("stonks_cli.app.sys")
+    def test_falls_back_to_webbrowser_when_xdg_open_missing(
+        self, mock_sys, _mock_popen, mock_wb
+    ):
+        mock_sys.platform = "linux"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com", new_tab=True)
+
+        mock_wb.assert_called_once_with("https://example.com", new=2)
+
+    @patch.object(PortfolioApp, "run_worker")
+    @patch("stonks_cli.app.sys")
+    @patch("stonks_cli.app.subprocess.Popen")
+    def test_reaps_child_via_textual_worker(self, mock_popen, mock_sys, mock_worker):
+        # Without reaping, ``xdg-open`` would linger as a zombie until the
+        # TUI itself exits.  Verify that a Textual worker is scheduled to
+        # call ``proc.wait`` so the kernel can clean up, and so the
+        # task is visible in devtools / reaped on app teardown.
+        mock_sys.platform = "linux"
+        fake_proc = MagicMock()
+        mock_popen.return_value = fake_proc
+
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com")
+
+        mock_worker.assert_called_once()
+        args, kwargs = mock_worker.call_args
+        assert args[0] is fake_proc.wait
+        assert kwargs["thread"] is True
+
+    @patch("stonks_cli.app.os")
+    @patch("stonks_cli.app.sys")
+    def test_windows_uses_startfile(self, mock_sys, mock_os):
+        # Windows path: bypasses subprocess / xdg-open and calls
+        # ``os.startfile`` directly, which detaches the URL handler
+        # natively without leaking stdio onto the TUI.
+        mock_sys.platform = "win32"
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com")
+
+        mock_os.startfile.assert_called_once_with("https://example.com")
+
+    @patch("stonks_cli.app.webbrowser.open")
+    @patch("stonks_cli.app.os")
+    @patch("stonks_cli.app.sys")
+    def test_windows_falls_back_to_webbrowser_when_startfile_fails(
+        self, mock_sys, mock_os, mock_wb
+    ):
+        mock_sys.platform = "win32"
+        mock_os.startfile.side_effect = OSError("association missing")
+        app = PortfolioApp(portfolios=[], prices={}, forex_rates=USD_RATES)
+        app.open_url("https://example.com", new_tab=True)
+
+        mock_wb.assert_called_once_with("https://example.com", new=2)


### PR DESCRIPTION
Textual's ``App.open_url`` (and Python's ``webbrowser.open`` underneath) spawns the system browser without redirecting its stdout / stderr, so anything the browser writes to those streams lands on the controlling terminal and corrupts the running TUI.

Override ``open_url`` to launch the OS URL handler (``xdg-open`` / ``open``) ourselves with stdin / stdout / stderr piped to ``DEVNULL`` and ``start_new_session=True`` so the child is detached cleanly.  Fall back to ``webbrowser.open`` if no system handler is on PATH so a misconfigured host still gets the user to the URL.