### PR TITLE
fix(exchanges): detect market holidays by passing a naive date to the calendar

### DIFF
--- a/src/stonks_cli/exchanges.py
+++ b/src/stonks_cli/exchanges.py
@@ -374,7 +374,17 @@ class ExchangeSession:
         if calendar_name:
             try:
                 cal = ExchangeSession.load_calendar(calendar_name)
-                today = pd.Timestamp.now(tz=zoneinfo.ZoneInfo("UTC")).normalize()
+                # ``cal.is_session`` requires a *tz-naive* date and uses the
+                # exchange's local calendar day.  Build today's date in the
+                # exchange's local timezone so the right session is checked
+                # (and so the previous fallback path -- which fired whenever
+                # is_session raised on a tz-aware timestamp -- is no longer
+                # reached, masking real US holidays like Memorial Day).
+                today = (
+                    pd.Timestamp.now(tz=zoneinfo.ZoneInfo(tz_name))
+                    .normalize()
+                    .tz_localize(None)
+                )
                 return bool(cal.is_session(today))
             except (AttributeError, LookupError, ValueError) as exc:
                 logger.debug(

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -693,6 +693,35 @@ class TestIsTradingDay:
             mock_dt.now.return_value.weekday.return_value = 2  # Wednesday
             assert ExchangeSession.is_trading_day(self._TZ) is True
 
+    @patch("stonks_cli.exchanges.pd.Timestamp.now")
+    def test_real_calendar_recognises_us_memorial_day(self, mock_now):
+        # Regression: ``cal.is_session`` requires a tz-naive timestamp, but a
+        # prior version passed a tz-aware UTC one and raised ``ValueError``.
+        # The except clause then fell through to the weekday check, which
+        # happily declared a Monday holiday a trading day.  This test runs
+        # the *real* exchange-calendars library to make sure a known US
+        # market holiday is detected as a non-trading day.
+        mock_now.return_value = pd.Timestamp("2026-05-25 12:00:00", tz="UTC")
+        assert ExchangeSession.is_trading_day(self._TZ, calendar_name="XNYS") is False
+
+    @patch("stonks_cli.exchanges.pd.Timestamp.now")
+    def test_real_calendar_recognises_ordinary_trading_day(self, mock_now):
+        mock_now.return_value = pd.Timestamp("2026-05-26 12:00:00", tz="UTC")
+        assert ExchangeSession.is_trading_day(self._TZ, calendar_name="XNYS") is True
+
+    @patch("stonks_cli.exchanges.pd.Timestamp.now")
+    def test_real_calendar_uses_exchange_local_date(self, mock_now):
+        # 2026-05-26 02:00 UTC == 2026-05-25 22:00 ET -- still Memorial Day
+        # in the exchange's local timezone, even though the UTC date has
+        # already rolled over to the 26th.  A fix that used the UTC date
+        # would look up the 26th (a regular trading day) and return True,
+        # masking the holiday.  The correct fix resolves "today" in the
+        # exchange's local tz and returns False.
+        mock_now.side_effect = lambda tz: pd.Timestamp(
+            "2026-05-26 02:00:00", tz="UTC"
+        ).astimezone(tz)
+        assert ExchangeSession.is_trading_day(self._TZ, calendar_name="XNYS") is False
+
 
 def _multi_day_close_df(
     prices: dict[str, list[float]],


### PR DESCRIPTION
## Summary
- ``exchange_calendars.ExchangeCalendar.is_session`` requires a tz-naive timestamp. The current ``is_trading_day`` built a tz-aware UTC one, which raised ``ValueError`` and triggered the ``except`` fallback to a weekday-only check.
- On a Monday holiday like Memorial Day or the UK Spring Bank Holiday the weekday check incorrectly said "trading day", ``current_session`` returned PRE / REGULAR / POST instead of CLOSED, and the STALE override flagged every US (and LSE) row as STALE because the last available bar was Friday's.

## Reproducer (before the fix)
2026-05-25 (Memorial Day in the US, Spring Bank Holiday in the UK), 04:52 ET:
```
NVDA       NASDAQ      214.30   STALE  <-- wrong, exchange is closed
KYIV       NASDAQ       13.93   STALE
COIN       NASDAQ      184.29   STALE
VUAA.L     LSE         144.52   STALE  <-- wrong, exchange is closed
```

## After the fix
``current_session`` for all four returns ``Session.CLOSED``, so the row badge renders ``CLS`` instead of ``STALE``. Continental EU exchanges (XPAR, XETR, etc.) that don't observe Whit Monday correctly stay in REGULAR / PRE / POST.

## Side benefit
Building the date in the exchange's local timezone also fixes a latent off-by-one for Asian exchanges late in the UTC day, where a Tokyo session was being looked up against the previous UTC calendar date.

## Test plan
- [x] Two new regression tests run the real ``exchange_calendars`` library against XNYS on 2026-05-25 (expected: not a session) and 2026-05-26 (expected: session). These would have caught the silent-fallback path.
- [x] All 7 ``TestIsTradingDay`` cases pass.
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy`` all clean.
- [x] Full ``make check-all`` minus the pre-existing time-decayed chart tests (fixed on ``test/chart_zoom_relative_dates``): 960 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)