### PR TITLE
Aggregate value for all portfolios

### DIFF
--- a/src/stonks_cli/app.py
+++ b/src/stonks_cli/app.py
@@ -42,6 +42,7 @@ from stonks_cli.models import (
     Portfolio,
     Position,
     WatchlistItem,
+    combined_portfolio_total,
     portfolio_total,
 )
 from stonks_cli.news_fetcher import NewsFetcher, NewsItem
@@ -408,6 +409,92 @@ class NewsItemRow(Horizontal):
         self.post_message(self.Selected(self._index))
 
 
+class _FooterWithTotal(Footer):
+    """``Footer`` subclass that injects a ``Total all portfolios`` label
+    just left of the command-palette indicator.
+
+    Multiple ``dock: right`` widgets in Textual all anchor to the same
+    right edge and overlap, so we can't simply yield a second
+    ``dock: right`` Static after the palette and expect them to stack.
+    Instead we ``dock: right`` the label and offset it leftwards by
+    ``margin-right`` equal to the rendered palette width plus a small
+    gap, putting it visually just to the left of ``^palette``.
+
+    When ``show_total`` is False the label is mounted with the
+    ``-hidden`` class so the DOM is identical between single- and
+    multi-portfolio modes; only its ``display`` flips.
+
+    Footer triggers a ``recompose`` once its ``_bindings_ready`` reactive
+    flips, which wipes any children the previous ``compose`` yielded
+    (including ours).  We cache the most recent renderable on the
+    instance so each recompose re-creates the Static with the value the
+    app last set via :meth:`set_total_renderable`, rather than flashing
+    back to empty between recompose and the next price refresh.
+    """
+
+    # The command-palette FooterKey renders with ``dock: right`` and a
+    # vertical-key border on the left.  Its width is the key glyph + label
+    # padding -- empirically ~12 cells in the default theme.  We clear it
+    # plus a 2-cell gap so the total doesn't visually collide with the
+    # palette border.
+    _PALETTE_GAP = 14
+
+    # A CSS class is used rather than a fixed ``id`` because Footer's
+    # ``_bindings_ready`` reactive triggers a ``recompose`` (and pushing
+    # another screen on top does too).  Textual's recompose asynchronously
+    # removes children before mounting fresh ones, but on Windows the
+    # removal hasn't always settled by the time ``mount_all`` runs, so a
+    # widget with a fixed ID gets reported as a duplicate and the whole
+    # screen push aborts.  Querying by class is collision-free.
+    _TOTAL_CLASS = "combined-total"
+
+    DEFAULT_CSS = f"""
+    _FooterWithTotal Static.{_TOTAL_CLASS} {{
+        dock: right;
+        width: auto;
+        padding: 0 1;
+        margin-right: {_PALETTE_GAP};
+        color: $accent;
+        text-style: bold;
+    }}
+    _FooterWithTotal Static.{_TOTAL_CLASS}.-hidden {{
+        display: none;
+    }}
+    """
+
+    def __init__(self, *, show_total: bool, **kw: Any) -> None:
+        super().__init__(**kw)
+        self._show_total = show_total
+        self._cached_renderable: Text | str = ""
+
+    def compose(self) -> ComposeResult:
+        yield from super().compose()
+        classes = self._TOTAL_CLASS
+        if not self._show_total:
+            classes += " -hidden"
+        yield Static(self._cached_renderable, classes=classes)
+
+    def set_total_renderable(self, renderable: Text | str) -> None:
+        """Update the cached label and any live Static instance.
+
+        Called by the app each time per-portfolio totals are refreshed.
+        Caching on the instance means the next recompose (triggered by
+        ``Footer`` itself when its bindings settle, or by a screen push
+        on top of the portfolio screen) re-creates the Static with the
+        latest value.
+
+        Iterates over ``query`` rather than calling ``query_one`` because
+        during recompose the old Static is briefly still in the DOM while
+        the new one mounts: ``query_one`` would raise ``TooManyMatches``
+        in that window.  Iteration covers 0, 1, or N matches without an
+        exception; if the Static isn't mounted yet the cached value is
+        picked up by the next ``compose``.
+        """
+        self._cached_renderable = renderable
+        for widget in self.query(f".{self._TOTAL_CLASS}").results(Static):
+            widget.update(renderable)
+
+
 class PortfolioApp(ThreadGuardMixin, App[None]):
     """Full-screen portfolio table with periodic price refresh."""
 
@@ -495,7 +582,14 @@ class PortfolioApp(ThreadGuardMixin, App[None]):
         yield Static("", id="status")
         yield Static("", id="error")
         yield NewsFeedWidget(id="news-panel")
-        yield Footer()
+        # The aggregate "Total all portfolios" label only renders when more
+        # than one portfolio is loaded -- in single-portfolio mode it would
+        # just duplicate the per-portfolio Total row.  We always mount it
+        # so the footer layout doesn't shift; visibility is toggled via the
+        # ``-hidden`` class on the Static inside.
+        yield _FooterWithTotal(
+            show_total=len(self.portfolios) > 1,
+        )
 
     def on_mount(self) -> None:
         self._populate_tables()
@@ -971,6 +1065,30 @@ class PortfolioApp(ThreadGuardMixin, App[None]):
         else:
             for i, portfolio in enumerate(self.portfolios):
                 self._populate_for(i, portfolio)
+            self._update_combined_total()
+
+    def _update_combined_total(self) -> None:
+        """Refresh the aggregate "Total all portfolios" label in the footer.
+
+        Goes through ``_FooterWithTotal.set_total_renderable`` rather than
+        updating the Static directly so the value survives the Footer's
+        post-``_bindings_ready`` recompose -- without the cache, the
+        label would flash to empty between recompose and the next price
+        refresh.
+        """
+        try:
+            footer = self.query_one(_FooterWithTotal)
+        except NoMatches:
+            return
+        total, base = combined_portfolio_total(
+            self.portfolios, self._snap.prices, self._snap.forex_rates
+        )
+        label = Text(f"Total ({base})  ")
+        if total is None:
+            renderable: Text = label.append("N/A", style="bold")
+        else:
+            renderable = label.append(f"{total:,.2f}", style="bold")
+        footer.set_total_renderable(renderable)
 
     def _populate_single(self) -> None:
         try:

--- a/src/stonks_cli/fetcher.py
+++ b/src/stonks_cli/fetcher.py
@@ -378,9 +378,14 @@ class PriceFetcher:
     ) -> dict[str, float]:
         """Return exchange rates: 1 unit of currency -> how many base units.
 
-        Uses yfinance forex pairs (e.g. EURUSD=X for EUR->USD).
-        The base currency is always included as 1.0. Currencies for which
-        no rate can be fetched are omitted from the result.
+        Uses yfinance forex pairs (e.g. ``EURUSD=X`` for EUR->USD).  When
+        a direct ``{currency}{base}=X`` ticker isn't published by Yahoo
+        (common for minor / less-traded currencies like ``UAH`` against
+        non-USD bases), the inverse pair ``{base}{currency}=X`` is used
+        and the rate reciprocated.  Both directions are requested in a
+        single batched yfinance call to avoid sequential network
+        round-trips.  The base currency is always included as 1.0.
+        Currencies for which neither pair resolves are omitted.
 
         Args:
             currencies: ISO 4217 currency codes (e.g. ['EUR', 'GBP']).
@@ -396,17 +401,36 @@ class PriceFetcher:
         if not non_base:
             return rates
 
-        symbols = [f"{c}{base}=X" for c in non_base]
-        close = _yf_download_close(
-            symbols, period="1d", description="forex", auto_adjust=False
-        )
-        if close is None:
-            return rates
+        # Request direct and inverse pairs together so Yahoo answers in a
+        # single round-trip even when minor currencies are present.  The
+        # inverse symbols are cheap to add to the batch and ``dict.fromkeys``
+        # de-dupes if any direct ticker happens to equal an inverse one
+        # (it never does for distinct currencies, but the guard is free).
+        direct_syms = [f"{c}{base}=X" for c in non_base]
+        inverse_syms = [f"{base}{c}=X" for c in non_base]
+        all_syms = list(dict.fromkeys(direct_syms + inverse_syms))
 
-        last = _last_close_per_symbol(close, symbols)
-        for currency, symbol in zip(non_base, symbols):
-            if symbol in last:
-                rates[currency] = last[symbol]
+        close = _yf_download_close(
+            all_syms, period="1d", description="forex", auto_adjust=False
+        )
+        downloaded = (
+            _last_close_per_symbol(close, all_syms) if close is not None else {}
+        )
+
+        for currency in non_base:
+            # Forex rates are always strictly positive in reality; checking
+            # ``> 0`` also drops the NaN values yfinance sometimes returns
+            # for unavailable symbols (NaN comparisons all evaluate False)
+            # without an explicit ``math.isnan`` guard.
+            direct_sym = f"{currency}{base}=X"
+            direct_rate = downloaded.get(direct_sym)
+            if direct_rate is not None and direct_rate > 0:
+                rates[currency] = direct_rate
+                continue
+            inverse_sym = f"{base}{currency}=X"
+            inv_rate = downloaded.get(inverse_sym)
+            if inv_rate is not None and inv_rate > 0:
+                rates[currency] = 1.0 / inv_rate
         return rates
 
     def fetch_stock_detail(self, symbol: str) -> StockDetail:

--- a/src/stonks_cli/models.py
+++ b/src/stonks_cli/models.py
@@ -299,3 +299,39 @@ def portfolio_total(
             return None
         total += cash_pos.amount * rate
     return total
+
+
+def combined_portfolio_total(
+    portfolios: "list[Portfolio]",
+    prices: dict[str, float],
+    forex_rates: dict[str, dict[str, float]],
+) -> tuple[float | None, str]:
+    """Return ``(total, base_currency)`` summed across all *portfolios*.
+
+    The aggregate is computed in the *first* portfolio's ``base_currency`` --
+    every position and cash balance across every portfolio is converted into
+    that currency using ``forex_rates[base]``.  ``base`` is returned alongside
+    the total so callers can render the label without having to look it up
+    themselves.
+
+    Returns ``(None, base)`` when any underlying portfolio's value cannot be
+    computed (missing price or forex rate) so the UI can render "N/A" rather
+    than a misleading partial sum.  Returns ``(None, "USD")`` when the list
+    is empty.
+
+    Args:
+        portfolios: Loaded portfolios to aggregate.
+        prices: Last prices keyed by symbol (shared across all portfolios).
+        forex_rates: Nested forex map ``{base_currency: {position_currency: rate}}``.
+    """
+    if not portfolios:
+        return None, "USD"
+    base = portfolios[0].base_currency
+    rates = forex_rates.get(base, {})
+    total = 0.0
+    for p in portfolios:
+        sub = portfolio_total(p, prices, rates)
+        if sub is None:
+            return None, base
+        total += sub
+    return total, base

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,7 @@ from textual.css.query import NoMatches
 from textual.widgets import Button, DataTable, Input, Label, Static
 
 from stonks_cli import app_actions
-from stonks_cli.app import PortfolioApp, PortfolioTableWidget
+from stonks_cli.app import PortfolioApp, PortfolioTableWidget, _FooterWithTotal
 from stonks_cli.forms import (
     CashFormScreen,
     ConfirmScreen,
@@ -2588,6 +2588,87 @@ async def test_action_chat_no_op_when_already_open(portfolio: Portfolio) -> None
         with patch.object(app, "push_screen") as mock_push:
             app.action_chat()
         mock_push.assert_not_called()
+
+
+def _static_content(widget: Static) -> str:
+    """Return the plain-text content currently displayed by a Static widget.
+
+    Uses the public ``render()`` API rather than poking the
+    name-mangled ``_Static__content`` attribute so the helper survives
+    Textual internal renames.
+    """
+    return str(widget.render())
+
+
+@pytest.mark.asyncio
+async def test_combined_total_widget_hidden_in_single_portfolio_mode(
+    portfolio: Portfolio,
+) -> None:
+    """The aggregate label is always mounted (so the footer layout stays
+    stable across single-/multi-portfolio modes) but is hidden via the
+    ``-hidden`` class when only one portfolio is loaded -- otherwise it
+    would just duplicate the per-portfolio Total row."""
+    app = PortfolioApp(portfolios=[portfolio], prices={}, forex_rates=USD_RATES)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.query_one(_FooterWithTotal).query_one(".combined-total", Static)
+        assert "-hidden" in widget.classes
+
+    multi = PortfolioApp(
+        portfolios=[portfolio, Portfolio(name="Second")],
+        prices={},
+        forex_rates=USD_RATES,
+    )
+    async with multi.run_test() as pilot:
+        await pilot.pause()
+        widget = multi.query_one(_FooterWithTotal).query_one(".combined-total", Static)
+        assert "-hidden" not in widget.classes
+
+
+@pytest.mark.asyncio
+async def test_combined_total_widget_renders_value(portfolio: Portfolio) -> None:
+    """When prices and forex rates are available, the aggregate footer
+    must display the summed value across all portfolios in the first
+    portfolio's base currency."""
+    second = Portfolio(
+        name="Second",
+        positions=[Position(symbol="MSFT", quantity=10, avg_cost=200.0)],
+    )
+    app = PortfolioApp(
+        portfolios=[portfolio, second],
+        prices={"AAPL": 200.0, "NVDA": 150.0, "MSFT": 300.0},
+        forex_rates=USD_RATES,
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.query_one(_FooterWithTotal).query_one(".combined-total", Static)
+        text = _static_content(widget)
+        # portfolio fixture: AAPL 100 @ 200 + NVDA 200 @ 150 = 50_000;
+        # second: MSFT 10 @ 300 = 3_000; total 53_000
+        assert "Total (USD)" in text
+        assert "53,000.00" in text
+
+
+@pytest.mark.asyncio
+async def test_combined_total_widget_renders_na_on_missing_price(
+    portfolio: Portfolio,
+) -> None:
+    """When any price is missing the aggregate must render ``N/A`` rather
+    than a misleading partial sum."""
+    second = Portfolio(
+        name="Second",
+        positions=[Position(symbol="MISSING", quantity=10, avg_cost=200.0)],
+    )
+    app = PortfolioApp(
+        portfolios=[portfolio, second],
+        prices={"AAPL": 200.0, "NVDA": 150.0},  # MISSING absent
+        forex_rates=USD_RATES,
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.query_one(_FooterWithTotal).query_one(".combined-total", Static)
+        text = _static_content(widget)
+        assert "N/A" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -364,8 +364,10 @@ class TestFetchForexRates:
     def test_uses_correct_yfinance_symbols(self, mock_dl, fetcher: PriceFetcher):
         mock_dl.return_value = _close_df({"EURUSD=X": 1.085})
         fetcher.fetch_forex_rates(["EUR"], base="USD")
+        # Direct and inverse pairs are batched so the inverse fallback
+        # path doesn't require a second network call.
         mock_dl.assert_called_once_with(
-            tickers=["EURUSD=X"],
+            tickers=["EURUSD=X", "USDEUR=X"],
             period="1d",
             auto_adjust=False,
             progress=False,
@@ -380,11 +382,55 @@ class TestFetchForexRates:
 
     @patch("stonks_cli.fetcher.yf.download")
     def test_omits_currency_with_no_data(self, mock_dl, fetcher: PriceFetcher):
-        # Only EUR returned, GBP missing from columns
+        # Only EUR returned, GBP missing from columns -- and the inverse
+        # ``USDGBP=X`` lookup also returns nothing, so GBP is dropped.
         mock_dl.return_value = _close_df({"EURUSD=X": 1.085})
         rates = fetcher.fetch_forex_rates(["EUR", "GBP"], base="USD")
         assert "EUR" in rates
         assert "GBP" not in rates
+
+    @patch("stonks_cli.fetcher.yf.download")
+    def test_falls_back_to_inverse_pair_when_direct_missing(
+        self, mock_dl, fetcher: PriceFetcher
+    ):
+        # Regression: UAH had no Yahoo entry for ``UAHEUR=X`` so the rate
+        # silently dropped, rendering ``N/A`` in the portfolio cash row
+        # even though Yahoo did publish the inverse ``EURUAH=X``.  The
+        # fetcher now batches direct and inverse pairs in a single call
+        # and reciprocates whichever direction Yahoo answered.
+        mock_dl.return_value = _close_df({"USDEUR=X": 0.86, "EURUAH=X": 51.68})
+        rates = fetcher.fetch_forex_rates(["USD", "UAH"], base="EUR")
+        assert rates["EUR"] == 1.0
+        assert rates["USD"] == pytest.approx(0.86)
+        # 1 / 51.68 -- 1 UAH in EUR
+        assert rates["UAH"] == pytest.approx(1.0 / 51.68)
+
+    @patch("stonks_cli.fetcher.yf.download")
+    def test_inverse_zero_rate_treated_as_missing(self, mock_dl, fetcher: PriceFetcher):
+        # If Yahoo were to return a bogus zero rate for the inverse pair
+        # we'd divide by zero -- guard against that and drop the
+        # currency rather than emit ``inf``.
+        mock_dl.return_value = _close_df({"USDEUR=X": 0.86, "EURUAH=X": 0.0})
+        rates = fetcher.fetch_forex_rates(["USD", "UAH"], base="EUR")
+        assert "UAH" not in rates
+
+    @patch("stonks_cli.fetcher.yf.download")
+    def test_direct_and_inverse_share_one_yfinance_call(
+        self, mock_dl, fetcher: PriceFetcher
+    ):
+        # Direct and inverse symbols are requested together so a portfolio
+        # with minor currencies doesn't pay for an extra network round-trip
+        # on every price refresh.
+        mock_dl.return_value = _close_df({"EURUSD=X": 1.085, "GBPUSD=X": 1.27})
+        fetcher.fetch_forex_rates(["EUR", "GBP"], base="USD")
+        assert mock_dl.call_count == 1
+        tickers = mock_dl.call_args.kwargs["tickers"]
+        # Both directions are in the batch so the inverse fallback is
+        # available without a follow-up call.
+        assert "EURUSD=X" in tickers
+        assert "USDEUR=X" in tickers
+        assert "GBPUSD=X" in tickers
+        assert "USDGBP=X" in tickers
 
 
 def _make_ticker(exchange_code: str | None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from stonks_cli.models import (
     Portfolio,
     Position,
     WatchlistItem,
+    combined_portfolio_total,
     daily_change_pct,
     portfolio_total,
 )
@@ -344,3 +345,72 @@ class TestPortfolioTotal:
         prices = {"VOW3": 120.0}
         rates = {"EUR": 1.1}  # EUR -> USD
         assert portfolio_total(p, prices, rates) == pytest.approx(5 * 120.0 * 1.1)
+
+
+class TestCombinedPortfolioTotal:
+    def test_empty_list_returns_none_usd(self):
+        total, base = combined_portfolio_total([], {}, {})
+        assert total is None
+        assert base == "USD"
+
+    def test_sums_across_portfolios_same_base(self):
+        p1 = Portfolio(
+            positions=[Position("AAPL", 10, 150.0)],
+            cash=[CashPosition("USD", 500.0)],
+            base_currency="USD",
+        )
+        p2 = Portfolio(
+            positions=[Position("NVDA", 5, 100.0)],
+            base_currency="USD",
+        )
+        prices = {"AAPL": 200.0, "NVDA": 120.0}
+        forex = {"USD": {"USD": 1.0}}
+        total, base = combined_portfolio_total([p1, p2], prices, forex)
+        # p1: 10*200 + 500 = 2500; p2: 5*120 = 600; combined = 3100
+        assert total == pytest.approx(3100.0)
+        assert base == "USD"
+
+    def test_uses_first_portfolio_base_currency(self):
+        # p1 base = EUR, p2 base = USD -- the aggregate is reported in EUR.
+        p1 = Portfolio(
+            positions=[Position("VOW3", 1, 100.0, currency="EUR")],
+            base_currency="EUR",
+        )
+        p2 = Portfolio(
+            positions=[Position("AAPL", 1, 100.0, currency="USD")],
+            base_currency="USD",
+        )
+        prices = {"VOW3": 200.0, "AAPL": 200.0}
+        # rates keyed by aggregate base ("EUR") -> {pos_currency: multiplier}
+        forex = {"EUR": {"EUR": 1.0, "USD": 0.9}}
+        total, base = combined_portfolio_total([p1, p2], prices, forex)
+        # p1 in EUR: 1*200*1.0 = 200; p2 USD->EUR: 1*200*0.9 = 180; total 380
+        assert total == pytest.approx(380.0)
+        assert base == "EUR"
+
+    def test_returns_none_when_any_portfolio_incomplete(self):
+        p1 = Portfolio(positions=[Position("AAPL", 10, 150.0)])
+        p2 = Portfolio(positions=[Position("MISSING", 1, 50.0)])
+        prices = {"AAPL": 200.0}  # MISSING has no price
+        forex = {"USD": {"USD": 1.0}}
+        total, base = combined_portfolio_total([p1, p2], prices, forex)
+        assert total is None
+        assert base == "USD"
+
+    def test_returns_none_when_base_rates_absent(self):
+        # forex_rates has no entry for the first portfolio's base -> the
+        # nested rates dict is empty, so any non-empty portfolio fails.
+        p1 = Portfolio(positions=[Position("AAPL", 10, 150.0)])
+        total, base = combined_portfolio_total([p1], {"AAPL": 200.0}, {})
+        assert total is None
+        assert base == "USD"
+
+    def test_single_portfolio_matches_portfolio_total(self):
+        p = Portfolio(
+            positions=[Position("AAPL", 10, 150.0)],
+            cash=[CashPosition("USD", 500.0)],
+        )
+        prices = {"AAPL": 200.0}
+        forex = {"USD": {"USD": 1.0}}
+        combined, _ = combined_portfolio_total([p], prices, forex)
+        assert combined == pytest.approx(portfolio_total(p, prices, {"USD": 1.0}))


### PR DESCRIPTION
Adds a Total (<base>) X,XXX.XX label in the footer, just left of ^palette, summing every loaded portfolio's current market value in the first portfolio's base currency. The footer was chosen because it's the natural status-bar slot - it stays visible no matter how deep the user scrolls into a portfolio table. The label stays mounted (hidden via CSS) in single-portfolio mode so the footer geometry doesn't shift between modes.

Also make fetch_forex_rates fall back to the inverse {base}{currency}=X ticker (and reciprocate) when the direct pair is missing. Yahoo only publishes major forex pairs in one direction, so a portfolio with UAH cash and an EUR base previously couldn't be valued for that row and rendered N/A. The fallback only runs when the direct pass leaves something unresolved, so the common case stays at one yfinance call.